### PR TITLE
🐛 / ✨ / ♻️ Decouple OpenAI Dependency, Standardize LLM & Agent Returns, Implement Chat History

### DIFF
--- a/examples/GradioAgentExample.xircuits
+++ b/examples/GradioAgentExample.xircuits
@@ -1,12 +1,12 @@
 {
     "id": "fa761208-4b12-47d3-b664-1f66f7335344",
-    "offsetX": 428.72189447951536,
-    "offsetY": -86.8619186112839,
-    "zoom": 48.04766845703125,
+    "offsetX": 284.5918909001595,
+    "offsetY": 126.50963602012237,
+    "zoom": 43.047668457031236,
     "gridSize": 0,
     "layers": [
         {
-            "id": "7f6b9765-ed86-40d5-b297-07c1800a90e3",
+            "id": "46ffb925-6e63-46f5-9648-cd04714df2e0",
             "type": "diagram-links",
             "isSvg": true,
             "transformed": true,
@@ -17,20 +17,20 @@
                     "selected": false,
                     "source": "e2c8f83e-4f69-430a-85ca-6c614531b0a9",
                     "sourcePort": "e291d7e2-8762-45f2-84a7-ebd3af368cd5",
-                    "target": "86136d09-eadb-4670-ac4a-511aac5b558b",
-                    "targetPort": "4cb39670-0ab8-45b6-ad1b-8f83f188e8f7",
+                    "target": "721bfc7c-4461-49ce-8352-0ff5e5dd3afb",
+                    "targetPort": "a8a0b557-78ee-40be-9b4d-29610accd303",
                     "points": [
                         {
                             "id": "67799334-1e46-4672-862e-e8edafae6bd1",
                             "type": "point",
-                            "x": -358.22503066679076,
-                            "y": 60.824999320806576
+                            "x": -358.22905827309387,
+                            "y": 60.562560379360335
                         },
                         {
                             "id": "3230d27e-175e-44c4-835c-6e144e439ec5",
                             "type": "point",
-                            "x": -205.43752724888657,
-                            "y": 59.47493791293897
+                            "x": -205.70816361906887,
+                            "y": 59.208385593173546
                         }
                     ],
                     "labels": [],
@@ -43,22 +43,22 @@
                     "id": "fd5bdc78-bc64-452c-81cf-e11240304c10",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "86136d09-eadb-4670-ac4a-511aac5b558b",
-                    "sourcePort": "ee9823ad-cee8-4dbd-9b7a-86576b7c6e19",
-                    "target": "1b390e88-7605-46bd-b2fa-3082dff9b8b6",
-                    "targetPort": "8e9b1c61-6d1a-4017-95f7-78500b806ccd",
+                    "source": "721bfc7c-4461-49ce-8352-0ff5e5dd3afb",
+                    "sourcePort": "0f0a0e38-e5bf-4411-8589-ff0c39d5391d",
+                    "target": "5bdc1739-622e-4274-9392-55ca06ae5ac4",
+                    "targetPort": "fdb0623e-0cdd-48c6-aaaa-1c11e667bcce",
                     "points": [
                         {
                             "id": "e3db8be0-425f-4ebf-b324-2e839b76ff7e",
                             "type": "point",
-                            "x": -67.25008995813191,
-                            "y": 59.47493791293897
+                            "x": -67.2498575624392,
+                            "y": 59.208385593173546
                         },
                         {
                             "id": "2d711674-e582-4fa2-9bcd-3263ff6af82d",
                             "type": "point",
-                            "x": 14.812558460899128,
-                            "y": 61.04993864704949
+                            "x": 14.54198304510505,
+                            "y": 60.78131078228388
                         }
                     ],
                     "labels": [],
@@ -71,22 +71,22 @@
                     "id": "1fa0339c-bd91-423e-b9dc-c0d0e78d212e",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "1b390e88-7605-46bd-b2fa-3082dff9b8b6",
-                    "sourcePort": "f6672a3e-cd42-43a4-8833-d349abb7f08a",
-                    "target": "b7c17027-db3a-460f-95fb-8025213ecfc5",
-                    "targetPort": "62cfce43-5e51-4e23-a295-3c41b58ca9d8",
+                    "source": "5bdc1739-622e-4274-9392-55ca06ae5ac4",
+                    "sourcePort": "da530efb-1193-424d-91e5-5ddedb5ed2d3",
+                    "target": "789af1b0-821f-4b8d-b1f4-d3b053c889de",
+                    "targetPort": "b193a307-70a9-463f-ab82-0ed7abe19f3a",
                     "points": [
                         {
                             "id": "f8d57c1b-b153-43a6-9d2a-1008f3a9e5a3",
                             "type": "point",
-                            "x": 172.9374302299072,
-                            "y": 61.04993864704949
+                            "x": 172.93753265920685,
+                            "y": 60.78131078228388
                         },
                         {
                             "id": "be8000fd-e4fc-4534-83b6-0c51182a5a25",
                             "type": "point",
-                            "x": 332.7250301309071,
-                            "y": 61.63744037745283
+                            "x": 332.4585136945475,
+                            "y": 61.375030086834904
                         }
                     ],
                     "labels": [],
@@ -99,10 +99,10 @@
                     "id": "59948ccc-8d0d-4104-ad20-4757522ddb7b",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "1a4d5743-141a-4ecf-ba8f-6cf4ba870fbc",
-                    "sourcePort": "62d882d1-954f-4837-9e1b-ef991a85a5e1",
-                    "target": "b7c17027-db3a-460f-95fb-8025213ecfc5",
-                    "targetPort": "b1d3603c-28b6-4738-adf4-2339cfe820dd",
+                    "source": "e3584bf6-9116-4b87-9afb-4612ef90965b",
+                    "sourcePort": "56162e56-a683-44d1-9fd7-f5387fcfb50e",
+                    "target": "789af1b0-821f-4b8d-b1f4-d3b053c889de",
+                    "targetPort": "a0f60c18-ef28-4f01-b19f-05d5cc4666a9",
                     "points": [
                         {
                             "id": "17d78dd7-b2e8-4e36-92b9-f008cf4d3497",
@@ -113,8 +113,8 @@
                         {
                             "id": "26a6611d-1656-4d8b-aab8-26fd15c9a35d",
                             "type": "point",
-                            "x": 332.4250709074092,
-                            "y": 82.43739631175433
+                            "x": 332.29183520878985,
+                            "y": 82.04168226351584
                         }
                     ],
                     "labels": [],
@@ -127,22 +127,22 @@
                     "id": "35c0974f-328c-438b-b69e-e7cb8727f4f0",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "b7c17027-db3a-460f-95fb-8025213ecfc5",
-                    "sourcePort": "5bf7092a-334c-46b1-8249-b85acc7eefd1",
-                    "target": "3b872944-98ca-4ddf-9a47-cb608a2684db",
-                    "targetPort": "54ea82f5-baa1-4fc4-9580-eb5ea007fafd",
+                    "source": "789af1b0-821f-4b8d-b1f4-d3b053c889de",
+                    "sourcePort": "ab64bf4f-1f63-4dbc-a6e9-81ebd0deb1d0",
+                    "target": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
+                    "targetPort": "e17e1b08-093d-42cc-9e51-71d9ae20ed1f",
                     "points": [
                         {
                             "id": "08f9a094-06a0-409d-8fe7-af04d3773b3c",
                             "type": "point",
-                            "x": 514.2124946218863,
-                            "y": 61.63744037745283
+                            "x": 513.9480595315706,
+                            "y": 61.375030086834904
                         },
                         {
                             "id": "5bb8d86a-b0c7-4475-9731-33082c679414",
                             "type": "point",
-                            "x": 1025.7750819762705,
-                            "y": 58.53747283085779
+                            "x": 1030.760667093845,
+                            "y": 53.01042500173452
                         }
                     ],
                     "labels": [],
@@ -155,22 +155,22 @@
                     "id": "cfb49a15-7c9d-4132-a8bd-ec2fb861889a",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "b7c17027-db3a-460f-95fb-8025213ecfc5",
-                    "sourcePort": "3f4c45a1-e964-4e09-8d0b-47945974a0f1",
-                    "target": "3b872944-98ca-4ddf-9a47-cb608a2684db",
-                    "targetPort": "78611fb3-94f9-4b79-b2a7-9d4997960edf",
+                    "source": "789af1b0-821f-4b8d-b1f4-d3b053c889de",
+                    "sourcePort": "f596926d-2df4-4315-86af-4a300a40e583",
+                    "target": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
+                    "targetPort": "3c40c46a-5af8-4c20-8205-d3c810baa620",
                     "points": [
                         {
                             "id": "a85f6e5c-fce1-4915-930d-f192af8e9da6",
                             "type": "point",
-                            "x": 514.2124946218863,
-                            "y": 83.23745044525413
+                            "x": 513.9480595315706,
+                            "y": 82.7083378284176
                         },
                         {
                             "id": "9886983b-3f84-42c0-ae73-34c3aa84a379",
                             "type": "point",
-                            "x": 1025.7750819762705,
-                            "y": 204.93750571328837
+                            "x": 1030.760667093845,
+                            "y": 197.0104390674295
                         }
                     ],
                     "labels": [],
@@ -183,16 +183,16 @@
                     "id": "acaf4f91-8afe-4639-a76f-450e5997e6bf",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "1b390e88-7605-46bd-b2fa-3082dff9b8b6",
-                    "sourcePort": "6cb78613-6553-452b-9bdf-c0b2d6a53105",
-                    "target": "3b872944-98ca-4ddf-9a47-cb608a2684db",
-                    "targetPort": "19aa22af-5306-4343-aac9-6989f6292ad3",
+                    "source": "5bdc1739-622e-4274-9392-55ca06ae5ac4",
+                    "sourcePort": "74d277e6-ec5d-4486-aefd-c0f58d1ad6f9",
+                    "target": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
+                    "targetPort": "f9e89463-01da-45bd-9aed-c42d28232df9",
                     "points": [
                         {
                             "id": "e82077bb-0948-4675-861a-083523f9b69c",
                             "type": "point",
-                            "x": 172.9374302299072,
-                            "y": 82.6499487148508
+                            "x": 172.93753265920685,
+                            "y": 82.1146185238666
                         },
                         {
                             "id": "134f00f2-6329-455f-b576-4f38d993dd8b",
@@ -203,8 +203,8 @@
                         {
                             "id": "9b860b14-536f-46d0-ae1e-ff0eadc4dd3a",
                             "type": "point",
-                            "x": 1025.7750819762705,
-                            "y": 140.13747550988444
+                            "x": 1030.760667093845,
+                            "y": 134.3438118628516
                         }
                     ],
                     "labels": [],
@@ -217,10 +217,10 @@
                     "id": "2c55f47c-f510-420c-bbfb-df5fd16bce7c",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "f0caf0ac-2116-427d-b92c-641343b1f5e0",
-                    "sourcePort": "0bbef686-ba5c-4e13-a02a-1c9013d5d9b7",
-                    "target": "3b872944-98ca-4ddf-9a47-cb608a2684db",
-                    "targetPort": "5bd60d52-b2cc-4577-8c11-9775c8c179e6",
+                    "source": "ae99a1db-ec89-482c-85e3-c0d8bad3036c",
+                    "sourcePort": "09b66859-ec10-4dcc-bded-055111197ced",
+                    "target": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
+                    "targetPort": "446418e2-5fa4-4ac2-b8d5-f6bc950673b5",
                     "points": [
                         {
                             "id": "a0f434da-9e70-4a01-bd8e-1403b0016922",
@@ -231,8 +231,8 @@
                         {
                             "id": "e9a8b665-5916-4f7b-80cd-8e371a167161",
                             "type": "point",
-                            "x": 1025.4751227527722,
-                            "y": 79.3374895437893
+                            "x": 1030.5939886080873,
+                            "y": 73.67712113371235
                         }
                     ],
                     "labels": [],
@@ -245,10 +245,10 @@
                     "id": "6e6ceca9-1911-4e82-a8c0-c62abb44bd97",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "440175cf-ff96-4109-8c7a-ad7a3525341a",
-                    "sourcePort": "802f1409-2866-437d-a149-cde28d41a579",
-                    "target": "3b872944-98ca-4ddf-9a47-cb608a2684db",
-                    "targetPort": "ddd8de9b-6638-4212-8ba8-79269a7e3194",
+                    "source": "ab1b9d01-b445-4f3c-8f7d-35aa6bbe1cc9",
+                    "sourcePort": "606f534f-e0ea-4554-9f7c-5c173f8e414b",
+                    "target": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
+                    "targetPort": "6fa4a4b9-7f76-43b4-a0db-2485937c92e5",
                     "points": [
                         {
                             "id": "d198c92f-def3-4404-a690-5e220fe581e5",
@@ -259,8 +259,8 @@
                         {
                             "id": "1c8350a7-4669-44a2-8f9c-3aa5bda106f2",
                             "type": "point",
-                            "x": 1025.4751227527722,
-                            "y": 99.33742113803709
+                            "x": 1030.5939886080873,
+                            "y": 93.67713285512485
                         }
                     ],
                     "labels": [],
@@ -273,22 +273,22 @@
                     "id": "3bcb0615-0fd9-4c36-80a3-1d960540b388",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "31edd7f8-b1f3-4d7f-a801-74c948bfeb46",
-                    "sourcePort": "40ec3b83-05fb-4deb-859d-fdd5d717c3b1",
-                    "target": "3b872944-98ca-4ddf-9a47-cb608a2684db",
-                    "targetPort": "10d32b90-2e7c-47ae-aabc-1047f7dd19cb",
+                    "source": "e08c1960-78ff-47fa-aba3-015199fe609b",
+                    "sourcePort": "a9de5979-20c0-4a9a-a4a2-08e6eaa99f05",
+                    "target": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
+                    "targetPort": "d37ca8bd-540a-4727-b3fd-a8933113f8ec",
                     "points": [
                         {
                             "id": "6299b5a9-3588-43e7-a282-1d414b1cd350",
                             "type": "point",
-                            "x": 755.5687259554167,
-                            "y": 737.0250304680669
+                            "x": 744.5937217835483,
+                            "y": 779.4583308227338
                         },
                         {
                             "id": "d9b73ab2-2d63-472a-adff-8d44868b37d3",
                             "type": "point",
-                            "x": 1025.7750819762705,
-                            "y": 183.33749564548708
+                            "x": 1030.5939886080873,
+                            "y": 176.34377178111527
                         }
                     ],
                     "labels": [],
@@ -301,10 +301,10 @@
                     "id": "44806538-bd83-41d4-9d83-4a7ac59af827",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "f0caf0ac-2116-427d-b92c-641343b1f5e0",
-                    "sourcePort": "0bbef686-ba5c-4e13-a02a-1c9013d5d9b7",
-                    "target": "d74c0df1-cd26-475e-82bd-7e8395b621c4",
-                    "targetPort": "2b3b8e5e-3dd3-4d86-8429-c984f30184d7",
+                    "source": "ae99a1db-ec89-482c-85e3-c0d8bad3036c",
+                    "sourcePort": "09b66859-ec10-4dcc-bded-055111197ced",
+                    "target": "8ba4e1d5-f9d7-4b6f-8e4f-b5fee61041f5",
+                    "targetPort": "edcec856-a1b5-4db1-b226-303654c16d8c",
                     "points": [
                         {
                             "id": "5ec8b4ff-0c04-46c0-9a5c-9cd889f13cf9",
@@ -315,8 +315,8 @@
                         {
                             "id": "00bed727-6518-4afb-9fc2-4495ff286fae",
                             "type": "point",
-                            "x": 2354.775284714712,
-                            "y": 64.38741477892395
+                            "x": 2319.135428782877,
+                            "y": -87.88540762037772
                         }
                     ],
                     "labels": [],
@@ -329,22 +329,22 @@
                     "id": "aad5e35e-a48f-4ea3-9866-2d8df4183fc1",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "65dfa2a6-1226-4d58-9f1f-535aa4d14b9f",
-                    "sourcePort": "25ed948c-d045-42b1-80e3-fb6a3868adc1",
-                    "target": "5c9150f1-227a-4874-944d-e5a25f48ac40",
-                    "targetPort": "f3bf6daa-c758-4cb0-bcad-d2f49a1434a9",
+                    "source": "a7714b3b-0162-4f09-88a7-24cf336046f3",
+                    "sourcePort": "4851e4f2-c0ab-41d7-bfe1-6c4ab0d81335",
+                    "target": "af98eb68-6175-4090-92a6-bd1e49333095",
+                    "targetPort": "5b5be0d2-359d-4397-a20e-8b0347ef204d",
                     "points": [
                         {
                             "id": "8f06e9b1-59a4-4ce8-97ff-9f26c5e450b5",
                             "type": "point",
-                            "x": -314.22504696976443,
-                            "y": 901.6375478722064
+                            "x": -314.48943561503205,
+                            "y": 902.0312763506348
                         },
                         {
                             "id": "f7289f59-ee27-4cd6-aacf-a2f27db369b6",
                             "type": "point",
-                            "x": -115.88750100205232,
-                            "y": 955.9625265830016
+                            "x": -116.15610325848306,
+                            "y": 955.6980565196459
                         }
                     ],
                     "labels": [],
@@ -357,22 +357,22 @@
                     "id": "5b230e36-c8f1-4be2-94c9-6a5dbfcbc442",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "01f7badd-faea-4c35-8600-530e2a6ee92e",
-                    "sourcePort": "9280b2e5-8028-4fcf-bbe2-8397a03ba259",
-                    "target": "5c9150f1-227a-4874-944d-e5a25f48ac40",
-                    "targetPort": "1b69180f-8bfc-4337-a2d2-99220c80d498",
+                    "source": "4ca44a22-f05f-4cd3-a416-2eb92f81f25e",
+                    "sourcePort": "9ede1ed4-5871-49ed-b400-5f87f80b8e5f",
+                    "target": "af98eb68-6175-4090-92a6-bd1e49333095",
+                    "targetPort": "bc318865-a866-48e1-a6ee-655d6115d95a",
                     "points": [
                         {
                             "id": "a9926410-1d95-4443-9a7f-63c42a3c19ac",
                             "type": "point",
-                            "x": -309.53749393743044,
-                            "y": 973.6500136407285
+                            "x": -309.81241620613116,
+                            "y": 974.0522061047958
                         },
                         {
                             "id": "00583261-c313-41c4-a437-9b17c0c6c0cd",
                             "type": "point",
-                            "x": -115.88750100205232,
-                            "y": 977.5625366508029
+                            "x": -116.15610325848306,
+                            "y": 977.0313203059317
                         }
                     ],
                     "labels": [],
@@ -385,22 +385,22 @@
                     "id": "e31af8e8-9442-41d4-b9de-f1bdddfefdc4",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "98803083-f227-4fab-9927-755a8992e8ff",
-                    "sourcePort": "c002447a-786c-4210-8d1c-282aff2f9f0f",
-                    "target": "5c9150f1-227a-4874-944d-e5a25f48ac40",
-                    "targetPort": "02191e3a-128b-4a12-a8d1-19d102a8e651",
+                    "source": "7f835863-6e95-4f2a-93e2-8a71f175d9e8",
+                    "sourcePort": "fcc1b3c6-94d1-416c-bcc5-5b95fd9e30bd",
+                    "target": "af98eb68-6175-4090-92a6-bd1e49333095",
+                    "targetPort": "5b01c091-6ad3-44db-9027-810342076eff",
                     "points": [
                         {
                             "id": "b2dffd03-7fa4-4e39-bbdf-dab41cb152f4",
                             "type": "point",
-                            "x": -310.80001147504447,
-                            "y": 1030.125001828223
+                            "x": -310.8019962275549,
+                            "y": 1030.5312461679978
                         },
                         {
                             "id": "0f283477-dc47-47f3-a27d-e22e3cdde005",
                             "type": "point",
-                            "x": -115.88750100205232,
-                            "y": 999.1625467186041
+                            "x": -116.15610325848306,
+                            "y": 998.3647015352764
                         }
                     ],
                     "labels": [],
@@ -413,22 +413,22 @@
                     "id": "90ec14ef-f1d7-48bf-b1a6-97788d305dc7",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "5c9150f1-227a-4874-944d-e5a25f48ac40",
-                    "sourcePort": "d3305da6-e57f-47fc-8a9c-44f115daa55f",
-                    "target": "bf0d4fb0-2d55-4e0c-87a6-adfd6bcd4ab4",
-                    "targetPort": "15d2c91a-eb18-45a5-acec-4cc048bef3ad",
+                    "source": "af98eb68-6175-4090-92a6-bd1e49333095",
+                    "sourcePort": "d634d75a-3bd5-4758-a30a-28d7bcc3e153",
+                    "target": "0864f0a0-0dc9-48b6-9348-18db03339de7",
+                    "targetPort": "bf5c22de-dd46-45ae-8151-c5091aba8e45",
                     "points": [
                         {
                             "id": "5459dd0f-9b23-4852-bb56-bce4dc2d5753",
                             "type": "point",
-                            "x": 44.42499744868849,
-                            "y": 955.9625265830016
+                            "x": 44.250137455960484,
+                            "y": 955.6980565196459
                         },
                         {
                             "id": "2c3b2074-4de5-48db-bf32-ef7fa45fb3df",
                             "type": "point",
-                            "x": 189.10006488198263,
-                            "y": 958.9625788287885
+                            "x": 188.83352622180712,
+                            "y": 958.6980934420952
                         }
                     ],
                     "labels": [],
@@ -441,22 +441,22 @@
                     "id": "37f942b9-d1eb-4637-a87b-7928d63a8813",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "bf0d4fb0-2d55-4e0c-87a6-adfd6bcd4ab4",
-                    "sourcePort": "0bd462dc-910e-4fe6-8b55-4c86ca241980",
-                    "target": "614ef7c7-82c6-4966-a89f-10c6caa99f7d",
-                    "targetPort": "db714b1a-6ca5-4b06-a0ac-44ed8618bc53",
+                    "source": "0864f0a0-0dc9-48b6-9348-18db03339de7",
+                    "sourcePort": "482c7a6f-8cd7-4b0f-9ec6-88da5c6f243f",
+                    "target": "c052005b-71c6-4471-a7b0-1d1c8d9c5915",
+                    "targetPort": "aa04a2e3-2ad1-4b97-bbde-548f62246c22",
                     "points": [
                         {
                             "id": "91e64b86-aba8-446d-8c2b-324e160e2cea",
                             "type": "point",
-                            "x": 321.55001499106953,
-                            "y": 958.9625788287885
+                            "x": 321.56258212723054,
+                            "y": 958.6980934420952
                         },
                         {
                             "id": "73255287-bb48-4e0c-9f6a-e8fc40a0d439",
                             "type": "point",
-                            "x": 459.76253002126725,
-                            "y": 958.4000404309952
+                            "x": 459.5000467615313,
+                            "y": 958.1354072639409
                         }
                     ],
                     "labels": [],
@@ -469,50 +469,22 @@
                     "id": "085de563-29ca-466a-9ac7-055026ef2d39",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "bf0d4fb0-2d55-4e0c-87a6-adfd6bcd4ab4",
-                    "sourcePort": "4830442b-d8eb-4705-8d3a-f6ccbd5f4609",
-                    "target": "614ef7c7-82c6-4966-a89f-10c6caa99f7d",
-                    "targetPort": "0de4606f-623a-404c-82a1-d21ea8c6b781",
+                    "source": "0864f0a0-0dc9-48b6-9348-18db03339de7",
+                    "sourcePort": "e2726af5-570a-478a-b4b3-f890c012ae05",
+                    "target": "c052005b-71c6-4471-a7b0-1d1c8d9c5915",
+                    "targetPort": "81c0475d-b3d2-4986-97e4-aa1cf0282a54",
                     "points": [
                         {
                             "id": "2fc90179-3f3e-4f44-963d-4b46f3deeab0",
                             "type": "point",
-                            "x": 321.55001499106953,
-                            "y": 980.5625126253678
+                            "x": 321.56258212723054,
+                            "y": 980.031357228381
                         },
                         {
                             "id": "5963ddb0-bbe8-436e-923e-e343b20c8c28",
                             "type": "point",
-                            "x": 459.76253002126725,
-                            "y": 980.0000504987966
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "3150865e-b75b-484b-97ed-6bedf5817401": {
-                    "id": "3150865e-b75b-484b-97ed-6bedf5817401",
-                    "type": "parameter-link",
-                    "selected": false,
-                    "source": "0d95013e-fcd1-432a-a34a-b152dfed1750",
-                    "sourcePort": "ba89445c-6a8a-45f9-8bbb-326765285e8d",
-                    "target": "86136d09-eadb-4670-ac4a-511aac5b558b",
-                    "targetPort": "ce868769-0dae-478b-a5f8-d96c29b95d55",
-                    "points": [
-                        {
-                            "id": "1e2ef004-6be0-4273-bf79-4e74df6c18f4",
-                            "type": "point",
-                            "x": -341.92500055872586,
-                            "y": 360.1750541026118
-                        },
-                        {
-                            "id": "f406ad73-48ff-43b6-a87a-66a94282454c",
-                            "type": "point",
-                            "x": -205.43752724888657,
-                            "y": 145.87496269155224
+                            "x": 459.5000467615313,
+                            "y": 979.4689052495429
                         }
                     ],
                     "labels": [],
@@ -525,22 +497,22 @@
                     "id": "dd6192f3-1f15-426b-9ecd-e030767446b1",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "2457e4b2-e281-42ab-b24e-232567c31e66",
-                    "sourcePort": "9d5cd5aa-6bca-4eac-b449-24411789c1cc",
-                    "target": "3cc38dc4-6215-4bfb-becf-9c1cbefc4eb5",
-                    "targetPort": "9d6a86b4-93fd-4efc-9598-a6c7c7d6adc7",
+                    "source": "937d0ee8-0b35-4305-ae78-e5699ed2170b",
+                    "sourcePort": "2c30b823-e614-41fa-8c57-6d7d785d2961",
+                    "target": "86117b35-2c6d-4e17-a963-3778daf93a53",
+                    "targetPort": "61e2966b-e05f-4d76-a2b0-cd595d2d8074",
                     "points": [
                         {
                             "id": "e112d5f6-030c-4ee0-8e41-0afb8a0990b5",
                             "type": "point",
-                            "x": 1473.0750163639516,
-                            "y": 57.89999795745848
+                            "x": 1473.0522266805247,
+                            "y": 57.62502788907006
                         },
                         {
                             "id": "96d4cb67-ac69-433f-8264-d4fd26c8647a",
                             "type": "point",
-                            "x": 1615.7000658925765,
-                            "y": -70.40000397792377
+                            "x": 1634.3856315816283,
+                            "y": -280.8333150259075
                         }
                     ],
                     "labels": [],
@@ -553,22 +525,22 @@
                     "id": "66bb0c96-c605-418b-94bc-df1adba9c3fb",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "2457e4b2-e281-42ab-b24e-232567c31e66",
-                    "sourcePort": "eb1b135c-c0b0-4348-a239-b9c5d79d648a",
-                    "target": "3cc38dc4-6215-4bfb-becf-9c1cbefc4eb5",
-                    "targetPort": "36c49ac2-a5e7-4175-adc6-cf9a63c41ebb",
+                    "source": "937d0ee8-0b35-4305-ae78-e5699ed2170b",
+                    "sourcePort": "7b2e47af-f979-432f-8ae3-fd343b6b52ae",
+                    "target": "86117b35-2c6d-4e17-a963-3778daf93a53",
+                    "targetPort": "e421943f-21f9-4edc-8c1a-b41733314d7f",
                     "points": [
                         {
                             "id": "af341cff-ea11-4bdf-9eed-60819444fd10",
                             "type": "point",
-                            "x": 1473.0750163639516,
-                            "y": 79.50000802525977
+                            "x": 1473.0522266805247,
+                            "y": 78.95837958594964
                         },
                         {
                             "id": "745da606-cceb-4be0-b8d2-d9a7a50eef36",
                             "type": "point",
-                            "x": 1615.7000658925765,
-                            "y": -48.79999391012248
+                            "x": 1634.3856315816283,
+                            "y": -259.4999557742113
                         }
                     ],
                     "labels": [],
@@ -581,10 +553,10 @@
                     "id": "961320c7-b2bd-4170-8caf-ce9c7eae2fff",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "dfcdef3c-3bb4-47ec-8137-266ed4aeddf2",
-                    "sourcePort": "0d76c278-5978-4859-9bb9-35890f6ea512",
-                    "target": "3b872944-98ca-4ddf-9a47-cb608a2684db",
-                    "targetPort": "7df3655d-750f-43a4-ab93-a1a06065f01f",
+                    "source": "d4f2147f-cea6-4ffc-b71b-e89eefa50bb4",
+                    "sourcePort": "64a48f91-db5b-4999-98d2-0e01dd43e600",
+                    "target": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
+                    "targetPort": "2330e3dd-9b31-4db8-8723-1c91be06d3e8",
                     "points": [
                         {
                             "id": "42059487-2a44-48c0-919b-bf8c8b106f9e",
@@ -595,8 +567,8 @@
                         {
                             "id": "ffb40ec7-e394-4659-a770-3c1035cef91c",
                             "type": "point",
-                            "x": 1025.4751227527722,
-                            "y": 119.33741351091487
+                            "x": 1030.5939886080873,
+                            "y": 113.67714457653736
                         }
                     ],
                     "labels": [],
@@ -609,50 +581,22 @@
                     "id": "407b43be-81b2-48ec-a06d-a68833c1d539",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "3cc38dc4-6215-4bfb-becf-9c1cbefc4eb5",
-                    "sourcePort": "aa6f6d0c-fcaf-4c2b-8b71-987bdffd12a1",
-                    "target": "e65a7e7a-470d-4c9e-ac6f-7492bef12d0f",
-                    "targetPort": "e6ba1834-ece7-4194-b1a5-0bb1c0bdc4b8",
+                    "source": "86117b35-2c6d-4e17-a963-3778daf93a53",
+                    "sourcePort": "d0e34393-06d9-4e68-8eda-4c6f795fed8f",
+                    "target": "0e04cedc-78e8-4fdf-be41-d1bf075f4c35",
+                    "targetPort": "930b7e5d-cc38-4088-8bea-543b20985257",
                     "points": [
                         {
                             "id": "d0783a6d-fbf5-4d08-b2db-e9f64e28c00e",
                             "type": "point",
-                            "x": 1738.012685137865,
-                            "y": -70.40000397792377
+                            "x": 1756.9689835532286,
+                            "y": -280.8333150259075
                         },
                         {
                             "id": "25588cd1-0bd2-4115-af73-40e2aabd38e4",
                             "type": "point",
-                            "x": 1858.92514827503,
-                            "y": -72.01246937462375
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "7dd0ca4e-a249-486a-a5b3-af9410efa66e": {
-                    "id": "7dd0ca4e-a249-486a-a5b3-af9410efa66e",
-                    "type": "parameter-link",
-                    "selected": false,
-                    "source": "9b675880-18d2-4ded-9e41-d83d578603d5",
-                    "sourcePort": "afe39e52-608b-47e3-b42c-215caae7777c",
-                    "target": "41aff0fa-745d-48dc-a878-9617f76afd85",
-                    "targetPort": "9d96038e-5623-4e52-99cd-ae58b4115e28",
-                    "points": [
-                        {
-                            "id": "58fa2226-b013-4d87-9a03-08ab41b78dfe",
-                            "type": "point",
-                            "x": 2421.579400119507,
-                            "y": 500.0752232498797
-                        },
-                        {
-                            "id": "39eef4b4-5dcc-4448-aac0-3cb08db87ecd",
-                            "type": "point",
-                            "x": 2758.0377099641482,
-                            "y": 92.8624520183481
+                            "x": 1832.8231668374394,
+                            "y": -361.6978966681829
                         }
                     ],
                     "labels": [],
@@ -665,22 +609,22 @@
                     "id": "18df1d85-cdb1-4140-a26a-abcc297d1fd9",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "3b872944-98ca-4ddf-9a47-cb608a2684db",
-                    "sourcePort": "3e300b46-b87c-492b-83c3-bdffbb409882",
-                    "target": "2457e4b2-e281-42ab-b24e-232567c31e66",
-                    "targetPort": "1fc00600-c86d-4261-9c30-8c92debc28b9",
+                    "source": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
+                    "sourcePort": "3c7f7c1a-d7ab-4af5-a37c-7cf682cb327f",
+                    "target": "937d0ee8-0b35-4305-ae78-e5699ed2170b",
+                    "targetPort": "488ffc1a-d517-47e2-8712-9c54ad9a9c98",
                     "points": [
                         {
                             "id": "433e3963-1c6a-472f-91d3-7d3934db20be",
                             "type": "point",
-                            "x": 1209.3250120736955,
-                            "y": 58.53747283085779
+                            "x": 1214.666816088236,
+                            "y": 53.01042500173452
                         },
                         {
                             "id": "63021133-2991-46e2-94b2-30b475384b38",
                             "type": "point",
-                            "x": 1318.0000317421368,
-                            "y": 57.89999795745848
+                            "x": 1317.729328139313,
+                            "y": 57.62502788907006
                         }
                     ],
                     "labels": [],
@@ -693,22 +637,22 @@
                     "id": "58aacc28-7bbd-48f8-b6fc-de12168e2931",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "d74c0df1-cd26-475e-82bd-7e8395b621c4",
-                    "sourcePort": "3835a3ad-2aea-4004-a9ad-b2b910453683",
-                    "target": "d8b5b14e-bcd5-4401-a725-d936918c7e15",
-                    "targetPort": "ec12b5a5-b6c4-4c0c-9c07-160f78a94e11",
+                    "source": "8ba4e1d5-f9d7-4b6f-8e4f-b5fee61041f5",
+                    "sourcePort": "b58fee7a-4169-4ebf-bb2f-333acec661b0",
+                    "target": "44b30e7b-899a-45a3-9832-f72261078b70",
+                    "targetPort": "9176b869-4c5b-4784-aa68-b5b6f8b99c85",
                     "points": [
                         {
                             "id": "c8bc2d69-cae7-4f93-b586-668ba16e0abc",
                             "type": "point",
-                            "x": 2601.024917897804,
-                            "y": 65.18740813379374
+                            "x": 2565.614580199498,
+                            "y": -87.21875205547596
                         },
                         {
                             "id": "9c7bbb91-f945-45af-84ea-dc1a922ce40f",
                             "type": "point",
-                            "x": 2775.0502193502753,
-                            "y": 262.75002418522496
+                            "x": 2675.708533181396,
+                            "y": 235.90630545270415
                         }
                     ],
                     "labels": [],
@@ -721,102 +665,22 @@
                     "id": "e43400e8-df06-4b04-9c2d-505ab9b615c1",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "2457e4b2-e281-42ab-b24e-232567c31e66",
-                    "sourcePort": "93362715-68a8-416e-8c15-1300d6418d28",
-                    "target": "1fe3ee5d-8dcb-44e4-836e-6ebe28f7487b",
-                    "targetPort": "4a6c5ff5-c61e-443e-9360-677701e92bfd",
+                    "source": "937d0ee8-0b35-4305-ae78-e5699ed2170b",
+                    "sourcePort": "11eda4e8-a9c5-40ec-9fca-fde23a628c51",
+                    "target": "543b7dc4-3c07-4258-a01c-ce62c7d5e15c",
+                    "targetPort": "f50dd76a-043b-42ee-b401-dfb44b6676a0",
                     "points": [
                         {
                             "id": "a1668362-b864-4e4c-b175-78ef27368b1c",
                             "type": "point",
-                            "x": 1473.0750163639516,
-                            "y": 122.7000281608624
+                            "x": 1473.0522266805247,
+                            "y": 121.62502391477864
                         },
                         {
                             "id": "0c4fce1c-8720-436f-b431-789ac201e263",
                             "type": "point",
-                            "x": 1708.5750442982867,
-                            "y": 146.48749687536053
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "a45a75e5-8707-41fe-a7f2-266b7dc80155": {
-                    "id": "a45a75e5-8707-41fe-a7f2-266b7dc80155",
-                    "type": "triangle-link",
-                    "selected": false,
-                    "source": "1fe3ee5d-8dcb-44e4-836e-6ebe28f7487b",
-                    "sourcePort": "04e04ab3-f377-4f0b-882b-0a67d6386d4e",
-                    "target": "ffbedfd5-a889-463c-8c8e-a674934cfdcc",
-                    "targetPort": "0d372d87-ff9f-415a-97af-f3b8bdf5704a",
-                    "points": [
-                        {
-                            "id": "207153e6-31fd-452d-97d0-b1fcce9167c7",
-                            "type": "point",
-                            "x": 1909.012643284032,
-                            "y": 43.28749962112451
-                        },
-                        {
-                            "id": "ea7affbe-6a05-4483-928d-ed2e18b58952",
-                            "type": "point",
-                            "x": 2125.762459089031,
-                            "y": 48.96247538594372
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "fefa6ade-23a9-4735-91a6-29720dad897e": {
-                    "id": "fefa6ade-23a9-4735-91a6-29720dad897e",
-                    "type": "parameter-link",
-                    "selected": false,
-                    "source": "2457e4b2-e281-42ab-b24e-232567c31e66",
-                    "sourcePort": "9bfea24c-7ac7-4823-b213-9ddda3036802",
-                    "target": "ffbedfd5-a889-463c-8c8e-a674934cfdcc",
-                    "targetPort": "b0157cf3-c761-4fe4-b32d-43dd28e4baa9",
-                    "points": [
-                        {
-                            "id": "1fdcc3ba-1b78-445e-a89a-739118d55e42",
-                            "type": "point",
-                            "x": 1473.0750163639516,
-                            "y": 144.3000382286637
-                        },
-                        {
-                            "id": "c5a630a8-c0d2-476d-9a22-6e40aa6a4313",
-                            "type": "point",
-                            "x": 1553.123178236065,
-                            "y": 143.67616741299597
-                        },
-                        {
-                            "id": "65dd22cd-d471-4af2-9175-066b239be6b6",
-                            "type": "point",
-                            "x": 1553.123178236065,
-                            "y": 260.7080262533326
-                        },
-                        {
-                            "id": "15f2a0a8-4c6b-4c12-b8ac-5e78b86861f7",
-                            "type": "point",
-                            "x": 2067.2743783099036,
-                            "y": 267.28284978368856
-                        },
-                        {
-                            "id": "d247bb53-ea78-4763-acdf-8e689267dec5",
-                            "type": "point",
-                            "x": 2067.2743783099036,
-                            "y": 71.3531085790801
-                        },
-                        {
-                            "id": "7248b068-0b04-4fab-9620-1450c61eb732",
-                            "type": "point",
-                            "x": 2125.762459089031,
-                            "y": 70.56248545374503
+                            "x": 1689.3649169153869,
+                            "y": -72.86457844143041
                         }
                     ],
                     "labels": [],
@@ -829,162 +693,22 @@
                     "id": "434ec92d-5fff-4711-9d58-1d717360dc3d",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "1fe3ee5d-8dcb-44e4-836e-6ebe28f7487b",
-                    "sourcePort": "9d183da3-7815-4f68-95ec-d4f2da20b941",
-                    "target": "ffbedfd5-a889-463c-8c8e-a674934cfdcc",
-                    "targetPort": "bb1e0d75-eafc-411e-987a-98741ab9807c",
+                    "source": "543b7dc4-3c07-4258-a01c-ce62c7d5e15c",
+                    "sourcePort": "07e6cea9-e1fe-4937-bb69-321ae58dcfb6",
+                    "target": "918d8b81-a46f-4962-800a-1edf2cb6f648",
+                    "targetPort": "1c58e91e-3abb-4f95-924e-c60a577ebd5b",
                     "points": [
                         {
                             "id": "239f77c9-8a35-4309-9d1d-44a31a707780",
                             "type": "point",
-                            "x": 1909.012643284032,
-                            "y": 64.88750968892582
+                            "x": 1889.802242357914,
+                            "y": -154.19790692441885
                         },
                         {
                             "id": "7aca0406-e20b-485c-962a-e3c330be3428",
                             "type": "point",
-                            "x": 2125.762459089031,
-                            "y": 92.16240375773236
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "316026a3-be2a-496a-9abc-12c8bc638fff": {
-                    "id": "316026a3-be2a-496a-9abc-12c8bc638fff",
-                    "type": "triangle-link",
-                    "selected": false,
-                    "source": "ffbedfd5-a889-463c-8c8e-a674934cfdcc",
-                    "sourcePort": "662cf5ac-fd42-4a47-acb3-c8b45732352f",
-                    "target": "d74c0df1-cd26-475e-82bd-7e8395b621c4",
-                    "targetPort": "f936b8a0-0c06-4e0a-98a2-bee2f8227200",
-                    "points": [
-                        {
-                            "id": "04092f73-4a6a-43e2-90b9-39e459d29407",
-                            "type": "point",
-                            "x": 2246.0876338168664,
-                            "y": 48.96247538594372
-                        },
-                        {
-                            "id": "21dccb60-3274-46d0-893d-02570dc69334",
-                            "type": "point",
-                            "x": 2355.0752439382104,
-                            "y": 43.58739806599243
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "acb29746-1b90-46fe-9c52-ab9d5a503d4d": {
-                    "id": "acb29746-1b90-46fe-9c52-ab9d5a503d4d",
-                    "type": "parameter-link",
-                    "selected": false,
-                    "source": "ffbedfd5-a889-463c-8c8e-a674934cfdcc",
-                    "sourcePort": "13f4c15b-3929-4f65-96de-633468fceb34",
-                    "target": "d74c0df1-cd26-475e-82bd-7e8395b621c4",
-                    "targetPort": "efbde000-a539-43b1-b74f-207f901530b1",
-                    "points": [
-                        {
-                            "id": "c93ec883-0e9b-42d2-9966-149a2b52ac4f",
-                            "type": "point",
-                            "x": 2246.0876338168664,
-                            "y": 70.56248545374503
-                        },
-                        {
-                            "id": "5c95cadb-0e0b-4b77-9159-e1ef34a89dc1",
-                            "type": "point",
-                            "x": 2355.0752439382104,
-                            "y": 85.18755304911551
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "dbc1d445-31ea-43aa-b9a7-d188e65b9c37": {
-                    "id": "dbc1d445-31ea-43aa-b9a7-d188e65b9c37",
-                    "type": "triangle-link",
-                    "selected": false,
-                    "source": "d74c0df1-cd26-475e-82bd-7e8395b621c4",
-                    "sourcePort": "191f4f0b-62b2-4b7c-82de-2a02d51f70ae",
-                    "target": "41aff0fa-745d-48dc-a878-9617f76afd85",
-                    "targetPort": "18bb550d-b233-4097-8a5e-087be6325ca2",
-                    "points": [
-                        {
-                            "id": "0f1d3b06-2cd1-4f69-87a1-067e8da665df",
-                            "type": "point",
-                            "x": 2601.024917897804,
-                            "y": 43.58739806599243
-                        },
-                        {
-                            "id": "b94b410b-14c0-4648-808a-be2dc355875f",
-                            "type": "point",
-                            "x": 2758.3376691876456,
-                            "y": -57.53747255894727
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "98aec024-4f48-4b5f-a944-258ee828b3e6": {
-                    "id": "98aec024-4f48-4b5f-a944-258ee828b3e6",
-                    "type": "triangle-link",
-                    "selected": false,
-                    "source": "2457e4b2-e281-42ab-b24e-232567c31e66",
-                    "sourcePort": "cc12fb45-1d9c-40d8-b46d-f41dd2c15b64",
-                    "target": "1fe3ee5d-8dcb-44e4-836e-6ebe28f7487b",
-                    "targetPort": "7210e51f-42b5-4186-a53e-2bdc6f477419",
-                    "points": [
-                        {
-                            "id": "88ca7d04-8ad5-4f77-bfb2-c7e023ba1f16",
-                            "type": "point",
-                            "x": 1473.0750163639516,
-                            "y": 101.1000180930611
-                        },
-                        {
-                            "id": "934e3bc2-9ce3-487e-a0a0-8db278c47171",
-                            "type": "point",
-                            "x": 1708.5750442982867,
-                            "y": 43.28749962112451
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "67edcd84-0152-4c7e-a93b-7da7b95ab778": {
-                    "id": "67edcd84-0152-4c7e-a93b-7da7b95ab778",
-                    "type": "parameter-link",
-                    "selected": false,
-                    "source": "d74c0df1-cd26-475e-82bd-7e8395b621c4",
-                    "sourcePort": "e67a89b1-9d9b-4ab4-afcb-8daf300437f7",
-                    "target": "41aff0fa-745d-48dc-a878-9617f76afd85",
-                    "targetPort": "82ff7589-4960-4f01-8c76-09ab1762eb84",
-                    "points": [
-                        {
-                            "id": "56eed9c3-5c96-4d98-980e-44d234b20332",
-                            "type": "point",
-                            "x": 2601.024917897804,
-                            "y": 108.38742826939634
-                        },
-                        {
-                            "id": "dc2dd930-8579-4c1e-87de-8988bcb2294d",
-                            "type": "point",
-                            "x": 2758.3376691876456,
-                            "y": -35.937462491145965
+                            "x": 2146.8855212355184,
+                            "y": -93.56246841135913
                         }
                     ],
                     "labels": [],
@@ -997,22 +721,22 @@
                     "id": "ef8a4b31-636b-4b25-982a-84d7e2b7ddb7",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "d74c0df1-cd26-475e-82bd-7e8395b621c4",
-                    "sourcePort": "e67a89b1-9d9b-4ab4-afcb-8daf300437f7",
-                    "target": "d8b5b14e-bcd5-4401-a725-d936918c7e15",
-                    "targetPort": "0b8c60ee-65ce-48ea-a3cc-5353aad05b1e",
+                    "source": "8ba4e1d5-f9d7-4b6f-8e4f-b5fee61041f5",
+                    "sourcePort": "69f117ea-215b-4b61-9dcf-188ad94e60ed",
+                    "target": "44b30e7b-899a-45a3-9832-f72261078b70",
+                    "targetPort": "13debabd-3930-4c62-b0be-560743eecd33",
                     "points": [
                         {
                             "id": "34679bee-eb78-403a-a721-45ce07a56774",
                             "type": "point",
-                            "x": 2601.024917897804,
-                            "y": 108.38742826939634
+                            "x": 2565.614580199498,
+                            "y": -44.552048661716775
                         },
                         {
                             "id": "0794179c-b087-4e2e-9f24-38ee96c4f884",
                             "type": "point",
-                            "x": 2775.0502193502753,
-                            "y": 284.3499424892123
+                            "x": 2675.708533181396,
+                            "y": 257.23962761711863
                         }
                     ],
                     "labels": [],
@@ -1025,10 +749,10 @@
                     "id": "3917abf5-443f-4b1f-809c-1d7dc6b3cc17",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "58650b5f-5eaf-4d12-8e81-e27dfbf82f28",
-                    "sourcePort": "54053683-805b-4e33-abaa-90aed9f9b7d0",
-                    "target": "1fe3ee5d-8dcb-44e4-836e-6ebe28f7487b",
-                    "targetPort": "a6b67d22-12cd-4cf1-b168-1169e8473605",
+                    "source": "0cce3adb-b828-4056-9c10-1260dc5a5e99",
+                    "sourcePort": "86c891a6-bd6a-45b3-b821-26733521d47c",
+                    "target": "543b7dc4-3c07-4258-a01c-ce62c7d5e15c",
+                    "targetPort": "6cae758b-23dd-49e2-afa4-6b46376f83ee",
                     "points": [
                         {
                             "id": "022858ab-aa19-47b6-845c-b9325da77e57",
@@ -1039,8 +763,8 @@
                         {
                             "id": "2c581d5d-9379-49be-a440-0ccb7c535257",
                             "type": "point",
-                            "x": 1708.2750850747889,
-                            "y": 64.087455555426
+                            "x": 1689.1983551858866,
+                            "y": -154.8645624893206
                         }
                     ],
                     "labels": [],
@@ -1053,10 +777,10 @@
                     "id": "97ba259a-33e9-4d99-b4c1-4fd4598099e9",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "adf28ede-0322-42a7-8efe-d7da0162357c",
-                    "sourcePort": "f17b2f06-7f3e-461a-a5fb-52ef28ca9200",
-                    "target": "1fe3ee5d-8dcb-44e4-836e-6ebe28f7487b",
-                    "targetPort": "cfd4e82d-eaf5-4607-a437-d3366e9f2e88",
+                    "source": "f2502fd7-4c63-48e7-ad8f-9be24567a16e",
+                    "sourcePort": "a9c6e206-49c4-412e-b69f-51f57f26331c",
+                    "target": "543b7dc4-3c07-4258-a01c-ce62c7d5e15c",
+                    "targetPort": "31359e66-2b10-4335-941d-357465db92ff",
                     "points": [
                         {
                             "id": "ab89d781-8a1f-47e7-a2da-a7bcbf3a04ed",
@@ -1067,8 +791,8 @@
                         {
                             "id": "988b0ead-c730-4d6f-ae32-069ee54c260b",
                             "type": "point",
-                            "x": 1708.2750850747889,
-                            "y": 84.08744792830382
+                            "x": 1689.1983551858866,
+                            "y": -134.8645507679081
                         }
                     ],
                     "labels": [],
@@ -1081,10 +805,10 @@
                     "id": "41df7e60-fab1-404d-93a3-91d55f1b0a69",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "5efe0234-cd2b-4c87-8f5e-47124aff058d",
-                    "sourcePort": "32e5677f-f725-4a3e-b8ab-5f0ff90c908e",
-                    "target": "1fe3ee5d-8dcb-44e4-836e-6ebe28f7487b",
-                    "targetPort": "f831c52c-5989-4e7d-aaa2-ad8639bcbe6b",
+                    "source": "101f9ad0-d628-4017-aa74-17d1b4116d00",
+                    "sourcePort": "1bb7e886-4767-49fc-846a-2a5499bbd2c6",
+                    "target": "543b7dc4-3c07-4258-a01c-ce62c7d5e15c",
+                    "targetPort": "f947c376-0e75-44fb-b4de-a3dd8387763e",
                     "points": [
                         {
                             "id": "81bf7bcd-1e52-4cf7-8607-792753373a53",
@@ -1095,8 +819,8 @@
                         {
                             "id": "8b7b3b09-0f74-48a8-9e8b-69c30bb02d53",
                             "type": "point",
-                            "x": 1708.2750850747889,
-                            "y": 125.68752664020491
+                            "x": 1689.1983551858866,
+                            "y": -93.53123130491288
                         }
                     ],
                     "labels": [],
@@ -1109,22 +833,22 @@
                     "id": "0fb2ba66-7383-4289-bdd8-bbadbdf7c7d6",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "11e4262d-dcc4-433d-899d-14d122497857",
-                    "sourcePort": "07d22c7e-58de-4830-b16e-7dded28f7db0",
-                    "target": "3c51c9e2-1b45-4818-bbf3-9c4d7893729f",
-                    "targetPort": "1ecd39af-3a41-4c27-beeb-285d2fbf43c4",
+                    "source": "a18bb71c-0ba8-405d-9c0f-54de9fd3f954",
+                    "sourcePort": "96631bd9-8cbd-4d7b-a099-d708d3412df2",
+                    "target": "8523af54-cfd0-49e4-8185-7784fe084c21",
+                    "targetPort": "62b512e0-3c09-45a6-bded-f2d7b495157a",
                     "points": [
                         {
                             "id": "bea0b7bd-b412-4d1c-b0dd-d98c66aa47be",
                             "type": "point",
-                            "x": -307.5125394713499,
-                            "y": 1122.6500323748473
+                            "x": -307.78121240497967,
+                            "y": 1123.0522231008438
                         },
                         {
                             "id": "7c87edc0-fcfc-472a-a959-ed4fbeead424",
                             "type": "point",
-                            "x": -116.13750257514627,
-                            "y": 1163.4250626354547
+                            "x": -116.40612098711946,
+                            "y": 1163.156274308545
                         }
                     ],
                     "labels": [],
@@ -1137,22 +861,22 @@
                     "id": "562eac0a-c234-49a5-a4b4-ce69754f37b6",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "12121537-9b70-4983-9dbf-7ab890cfb8ef",
-                    "sourcePort": "3efa3ed2-9428-4698-bbec-fa23a1b933ff",
-                    "target": "3c51c9e2-1b45-4818-bbf3-9c4d7893729f",
-                    "targetPort": "bc26e355-b3c6-44b6-b08b-7c76ddc4e3fa",
+                    "source": "ee568f94-4132-4278-ba48-b0207705b29e",
+                    "sourcePort": "b9c7ef9c-2bfd-429a-9e59-a7622bed4618",
+                    "target": "8523af54-cfd0-49e4-8185-7784fe084c21",
+                    "targetPort": "73d71bcc-91b6-4296-b905-be1d4e5f0675",
                     "points": [
                         {
                             "id": "eb90b20b-14c9-4ce5-a65c-897be1cdeb46",
                             "type": "point",
-                            "x": -308.48749900946666,
-                            "y": 1255.9000771365208
+                            "x": -308.48942014826196,
+                            "y": 1256.291746291732
                         },
                         {
                             "id": "c70d6a0d-d3ef-4af1-99c6-9bbef641c461",
                             "type": "point",
-                            "x": -116.13750257514627,
-                            "y": 1206.6250827710574
+                            "x": -116.40612098711946,
+                            "y": 1205.8229777023041
                         }
                     ],
                     "labels": [],
@@ -1165,50 +889,22 @@
                     "id": "3dc4faa9-5335-4905-89c6-96efbc669d14",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "b71100b5-7f7e-4c82-9be7-40c507dfce75",
-                    "sourcePort": "15929f8f-5152-48d3-aef2-2d8aa064a5cf",
-                    "target": "3c51c9e2-1b45-4818-bbf3-9c4d7893729f",
-                    "targetPort": "5087d713-67e3-486b-97ab-594796075871",
+                    "source": "2eaca646-a1e9-47f9-95be-364600f39f33",
+                    "sourcePort": "960c62be-352a-44e3-965b-11c3a241fe3a",
+                    "target": "8523af54-cfd0-49e4-8185-7784fe084c21",
+                    "targetPort": "b52b4fef-b973-4764-b8d8-f3ed6af8b923",
                     "points": [
                         {
                             "id": "39d7dfd5-e777-4071-93bc-c45254fc8332",
                             "type": "point",
-                            "x": -307.5125394713499,
-                            "y": 1190.6500407646818
+                            "x": -307.7915274769139,
+                            "y": 1192.1875171474946
                         },
                         {
                             "id": "868b0ccf-fbf2-4985-9303-e85b547bc72b",
                             "type": "point",
-                            "x": -116.13750257514627,
-                            "y": 1185.0250727032562
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "0cc96856-42f8-4d89-83e0-9f53fe3ed0ca": {
-                    "id": "0cc96856-42f8-4d89-83e0-9f53fe3ed0ca",
-                    "type": "triangle-link",
-                    "selected": false,
-                    "source": "4682114a-3217-4ecb-acf2-bd358b27eae4",
-                    "sourcePort": "18b128c1-f5fa-4f4b-ae8e-6442e5bfb698",
-                    "target": "86136d09-eadb-4670-ac4a-511aac5b558b",
-                    "targetPort": "18debe53-c0d6-41a1-b1d5-93e639f37988",
-                    "points": [
-                        {
-                            "id": "7696d9d1-e81e-4554-9453-5f69c08eca16",
-                            "type": "point",
-                            "x": -340.2375462499548,
-                            "y": 254.6250034489865
-                        },
-                        {
-                            "id": "4c199642-7110-47e3-985e-4a97f99b04a5",
-                            "type": "point",
-                            "x": -205.43752724888657,
-                            "y": 124.27495262375092
+                            "x": -116.40612098711946,
+                            "y": 1184.4897139160184
                         }
                     ],
                     "labels": [],
@@ -1221,22 +917,22 @@
                     "id": "cbda0e1d-fb8c-48d5-b495-bcfc9032fdaf",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "507ae692-69b1-4bf1-8cb1-698b360ff0ba",
-                    "sourcePort": "6149dbe2-9e5b-4b03-86e6-64cf47b176ef",
-                    "target": "3b872944-98ca-4ddf-9a47-cb608a2684db",
-                    "targetPort": "cfbe31dc-0198-4054-a430-349517d9389a",
+                    "source": "bf761ee7-8ae7-4523-b8bd-2e239df1408b",
+                    "sourcePort": "5b1d2330-bf8d-43b7-9a1e-8c107228f223",
+                    "target": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
+                    "targetPort": "d676331c-d951-4a23-a1cf-14ea927026be",
                     "points": [
                         {
                             "id": "367156d6-d085-4b5a-9f9f-b932b8df79e2",
                             "type": "point",
-                            "x": 765.3126116600765,
-                            "y": 449.2375403976266
+                            "x": 762.718807652281,
+                            "y": 476.0526585536945
                         },
                         {
                             "id": "5b63e69e-2396-4756-b770-ea24dc257a27",
                             "type": "point",
-                            "x": 1025.7750819762705,
-                            "y": 161.7374855776858
+                            "x": 1030.760667093845,
+                            "y": 155.67716355973118
                         }
                     ],
                     "labels": [],
@@ -1249,22 +945,22 @@
                     "id": "6c4f75f8-0732-40ac-9861-d7d3d6fc83f3",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "6b843293-5419-4d8b-b9cf-d2432b7fbf01",
-                    "sourcePort": "5fcfc361-c856-4504-877c-182ba0d35d1c",
-                    "target": "5bfa0140-dfc0-4e82-9f57-4037e08fe65c",
-                    "targetPort": "49cf4bac-81a7-4f75-8192-e3016154cd1f",
+                    "source": "c426ad10-584a-4395-976d-8adf25202a16",
+                    "sourcePort": "3c1a5f92-0e86-4bb6-81f0-3319cbdbf81b",
+                    "target": "8e871605-ef71-44a4-b813-8f32cc7f7ee1",
+                    "targetPort": "df9225b1-fad9-4972-9272-67038705ad0b",
                     "points": [
                         {
                             "id": "8ffbd0cc-d743-4d83-8405-a72144234cc8",
                             "type": "point",
-                            "x": 94.21256302763854,
-                            "y": 1398.1875785403881
+                            "x": 138.03122483967675,
+                            "y": 1366.2916933164418
                         },
                         {
                             "id": "75f58919-e172-42a5-a707-b35f897d9db7",
                             "type": "point",
-                            "x": 192.3999547940076,
-                            "y": 1227.9750376375619
+                            "x": 192.13544812320777,
+                            "y": 1226.9168314093326
                         }
                     ],
                     "labels": [],
@@ -1277,22 +973,22 @@
                     "id": "af8adecb-7bc3-4904-911e-bf61f790b080",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "3c51c9e2-1b45-4818-bbf3-9c4d7893729f",
-                    "sourcePort": "a0f16440-d7e1-455c-908a-1c4ddd0f1121",
-                    "target": "5bfa0140-dfc0-4e82-9f57-4037e08fe65c",
-                    "targetPort": "db9450ad-668c-4a2c-9364-19503cce6cd0",
+                    "source": "8523af54-cfd0-49e4-8185-7784fe084c21",
+                    "sourcePort": "c6e3392c-d9a5-42b1-a597-2d0ce927dfb0",
+                    "target": "8e871605-ef71-44a4-b813-8f32cc7f7ee1",
+                    "targetPort": "46506216-7b9f-4aad-bb80-b2837a64f635",
                     "points": [
                         {
                             "id": "f997078c-6c0c-4ba6-a8eb-742cfb035570",
                             "type": "point",
-                            "x": 44.17499587559453,
-                            "y": 1185.0250727032562
+                            "x": 44.000119727324076,
+                            "y": 1184.4897139160184
                         },
                         {
                             "id": "dea8036b-9686-486d-92e8-735a90b7c496",
                             "type": "point",
-                            "x": 192.3999547940076,
-                            "y": 1184.7750175019592
+                            "x": 192.13544812320777,
+                            "y": 1184.250069637445
                         }
                     ],
                     "labels": [],
@@ -1305,22 +1001,22 @@
                     "id": "10981437-9f4a-4441-9597-8717da00f3a2",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "3c51c9e2-1b45-4818-bbf3-9c4d7893729f",
-                    "sourcePort": "d1f17b75-d915-4a8c-a6d4-e1d472c42809",
-                    "target": "5bfa0140-dfc0-4e82-9f57-4037e08fe65c",
-                    "targetPort": "1c076e9d-5263-49d3-ba61-ec469c098aff",
+                    "source": "8523af54-cfd0-49e4-8185-7784fe084c21",
+                    "sourcePort": "5ef1e615-846a-432e-ab2d-126f1c068a4c",
+                    "target": "8e871605-ef71-44a4-b813-8f32cc7f7ee1",
+                    "targetPort": "11ba0d3c-f94c-4cfc-80fd-ac3b78682ded",
                     "points": [
                         {
                             "id": "0def8372-5d4d-42de-b7bc-bfd12fa2e26d",
                             "type": "point",
-                            "x": 44.17499587559453,
-                            "y": 1163.4250626354547
+                            "x": 44.000119727324076,
+                            "y": 1163.156274308545
                         },
                         {
                             "id": "76de1c91-9c40-4dc4-a71a-9ea389720bef",
                             "type": "point",
-                            "x": 192.3999547940076,
-                            "y": 1163.1750682127881
+                            "x": 192.13544812320777,
+                            "y": 1162.916805851159
                         }
                     ],
                     "labels": [],
@@ -1333,22 +1029,22 @@
                     "id": "5819af48-c165-4108-9bb1-a5075a1537fc",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "5bfa0140-dfc0-4e82-9f57-4037e08fe65c",
-                    "sourcePort": "2be15f97-c738-458e-9d68-9ed7fbe7e807",
-                    "target": "71dea741-3947-4377-894c-44f4ab5bfe52",
-                    "targetPort": "2cf08fab-5205-4cfd-af0f-f88db9c508cf",
+                    "source": "8e871605-ef71-44a4-b813-8f32cc7f7ee1",
+                    "sourcePort": "73ed47f7-c86b-44c4-8237-2e22d1be8917",
+                    "target": "1754e07e-0300-4b92-83d5-0ec692303f0e",
+                    "targetPort": "6aa45db2-4cfb-42e3-8515-f175074ea474",
                     "points": [
                         {
                             "id": "159de975-4c8f-44b8-b5f5-bf8bf7df31b4",
                             "type": "point",
-                            "x": 343.91249297252114,
-                            "y": 1163.1750682127881
+                            "x": 343.37507540573307,
+                            "y": 1162.916805851159
                         },
                         {
                             "id": "5b084bf9-9fb8-499b-b5e0-4a7e2e5792b9",
                             "type": "point",
-                            "x": 495.0624687468743,
-                            "y": 1161.4250405168004
+                            "x": 494.7915788028915,
+                            "y": 1161.1563083006413
                         }
                     ],
                     "labels": [],
@@ -1361,22 +1057,454 @@
                     "id": "f0128e69-2aad-49be-b112-a8cf6841f19c",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "5bfa0140-dfc0-4e82-9f57-4037e08fe65c",
-                    "sourcePort": "da54dd08-7936-41f6-9178-65152919cb54",
-                    "target": "71dea741-3947-4377-894c-44f4ab5bfe52",
-                    "targetPort": "4f52067f-0d74-4f7b-8488-5c03ca205d08",
+                    "source": "8e871605-ef71-44a4-b813-8f32cc7f7ee1",
+                    "sourcePort": "3e4eab61-097b-4c2b-818c-6e3660356381",
+                    "target": "1754e07e-0300-4b92-83d5-0ec692303f0e",
+                    "targetPort": "239c1bf2-f0df-4af2-bfc2-bf0ff1db71b9",
                     "points": [
                         {
                             "id": "ec5cfaa7-59a8-43a3-85f8-f029d4d01db9",
                             "type": "point",
-                            "x": 343.91249297252114,
-                            "y": 1184.7750175019592
+                            "x": 343.37507540573307,
+                            "y": 1184.250069637445
                         },
                         {
                             "id": "faf5ea54-a854-48a8-beab-894faa840795",
                             "type": "point",
-                            "x": 495.0624687468743,
-                            "y": 1183.0250505846016
+                            "x": 494.7915788028915,
+                            "y": 1182.4896304650558
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "62e4919b-12d7-4823-8dfe-fabfb204013f": {
+                    "id": "62e4919b-12d7-4823-8dfe-fabfb204013f",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "8ba4e1d5-f9d7-4b6f-8e4f-b5fee61041f5",
+                    "sourcePort": "69f117ea-215b-4b61-9dcf-188ad94e60ed",
+                    "target": "b51635e5-1d86-49ed-9996-61992c3f9209",
+                    "targetPort": "052cca44-5117-47ee-bbb7-b518f47f8abd",
+                    "points": [
+                        {
+                            "id": "75e8a833-6ba0-4fec-a382-0572806fa92a",
+                            "type": "point",
+                            "x": 2565.614580199498,
+                            "y": -44.552048661716775
+                        },
+                        {
+                            "id": "9dd0e07f-6194-44de-80ee-44c775c2855c",
+                            "type": "point",
+                            "x": 2913.4687119094942,
+                            "y": 65.59375646086283
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "32449492-6723-426b-9bc3-1d01a04cc893": {
+                    "id": "32449492-6723-426b-9bc3-1d01a04cc893",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "937d0ee8-0b35-4305-ae78-e5699ed2170b",
+                    "sourcePort": "11eda4e8-a9c5-40ec-9fca-fde23a628c51",
+                    "target": "b51635e5-1d86-49ed-9996-61992c3f9209",
+                    "targetPort": "b14cb31d-6ea8-47d4-9fcf-fa30fbd3d5a6",
+                    "points": [
+                        {
+                            "id": "5714707f-8bbf-4219-81c1-711cee5ad6f1",
+                            "type": "point",
+                            "x": 1473.0522266805247,
+                            "y": 121.62502391477864
+                        },
+                        {
+                            "id": "091ad6ee-3648-4348-bda8-90347e166664",
+                            "type": "point",
+                            "x": 2913.4687119094942,
+                            "y": 22.927097022400538
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "935964df-7e09-4c1e-ad42-f95f83c5a53a": {
+                    "id": "935964df-7e09-4c1e-ad42-f95f83c5a53a",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "937d0ee8-0b35-4305-ae78-e5699ed2170b",
+                    "sourcePort": "00e420dc-04ed-4560-a48f-2625998d1728",
+                    "target": "b51635e5-1d86-49ed-9996-61992c3f9209",
+                    "targetPort": "69cfaf6c-c084-4cef-b8b8-0d7ffdc23133",
+                    "points": [
+                        {
+                            "id": "669d094a-b4e4-4365-8b24-f093b893be80",
+                            "type": "point",
+                            "x": 1473.0522266805247,
+                            "y": 142.95837561165823
+                        },
+                        {
+                            "id": "0554e83e-ccc9-4db3-b8da-6a21a9fe2454",
+                            "type": "point",
+                            "x": 2913.4687119094942,
+                            "y": 44.26044871928012
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "15b071f0-8734-455e-b5b5-f588001173fc": {
+                    "id": "15b071f0-8734-455e-b5b5-f588001173fc",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "de0a966a-06ae-4eef-b06b-d672c27a5a2f",
+                    "sourcePort": "b290d782-14c2-4983-a1bf-45c34ecacb8b",
+                    "target": "8e871605-ef71-44a4-b813-8f32cc7f7ee1",
+                    "targetPort": "dcb5e435-b068-46d5-998c-66356de88421",
+                    "points": [
+                        {
+                            "id": "46094f47-a4d7-494b-bb84-8b280ae4c223",
+                            "type": "point",
+                            "x": 127.87508976446338,
+                            "y": 1298.5312625779752
+                        },
+                        {
+                            "id": "b21ef56b-44e7-47f3-905c-650352420d17",
+                            "type": "point",
+                            "x": 192.13544812320777,
+                            "y": 1205.5833334237307
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "a7ce3ded-ad54-4dce-8010-54a5fa121b9c": {
+                    "id": "a7ce3ded-ad54-4dce-8010-54a5fa121b9c",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "891e6f05-40a9-4cf2-b1e7-4c51d0e2cae6",
+                    "sourcePort": "93569724-e064-415c-ad23-0a5ba157cc7b",
+                    "target": "721bfc7c-4461-49ce-8352-0ff5e5dd3afb",
+                    "targetPort": "f48016e4-5b53-4aae-b061-cb98076cc452",
+                    "points": [
+                        {
+                            "id": "f33e4edc-bd4e-4676-b222-4fcc50b555bb",
+                            "type": "point",
+                            "x": -271.20829554906095,
+                            "y": 205.8854530598657
+                        },
+                        {
+                            "id": "53ffdf0a-5453-4e16-ab7c-908459b5cedb",
+                            "type": "point",
+                            "x": -205.70816361906887,
+                            "y": 123.20838161888213
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "6f499d27-3271-4976-a976-65d747484f2b": {
+                    "id": "6f499d27-3271-4976-a976-65d747484f2b",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "937d0ee8-0b35-4305-ae78-e5699ed2170b",
+                    "sourcePort": "93393714-5454-430e-aef9-3eed1a690345",
+                    "target": "543b7dc4-3c07-4258-a01c-ce62c7d5e15c",
+                    "targetPort": "f4ca7d29-16e5-4236-9d48-f58743d9842b",
+                    "points": [
+                        {
+                            "id": "75dc7791-daca-4bc0-b690-73f56d1d8e94",
+                            "type": "point",
+                            "x": 1473.0522266805247,
+                            "y": 100.29168732753234
+                        },
+                        {
+                            "id": "635c2003-a60b-412d-a21e-b71ece2463f2",
+                            "type": "point",
+                            "x": 1689.3649169153869,
+                            "y": -175.53121466600155
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "c9471436-1c46-401d-b93e-0a73b7d2f7b5": {
+                    "id": "c9471436-1c46-401d-b93e-0a73b7d2f7b5",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "8ba4e1d5-f9d7-4b6f-8e4f-b5fee61041f5",
+                    "sourcePort": "63d02692-589e-4f3c-bd28-4e374b15540c",
+                    "target": "c304a0df-a115-4489-8114-73a0c87ae1d0",
+                    "targetPort": "cfdf0ab8-65e3-4fff-8f3a-5b6dc0b738d6",
+                    "points": [
+                        {
+                            "id": "e831046e-8353-452d-b64c-711fd2d4318a",
+                            "type": "point",
+                            "x": 2565.614580199498,
+                            "y": -108.55205979705866
+                        },
+                        {
+                            "id": "d4ee2849-0d66-4c3c-9385-f0a802d60c6a",
+                            "type": "point",
+                            "x": 2702.500165733868,
+                            "y": -92.38534556099293
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "584f34af-e97b-44af-aa0a-0bd8155d42cf": {
+                    "id": "584f34af-e97b-44af-aa0a-0bd8155d42cf",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "c304a0df-a115-4489-8114-73a0c87ae1d0",
+                    "sourcePort": "a2e5e722-0db4-4c12-8469-5fee0e274ee0",
+                    "target": "b51635e5-1d86-49ed-9996-61992c3f9209",
+                    "targetPort": "b4a8749c-9a69-4dd4-83ca-b2b347a2b02c",
+                    "points": [
+                        {
+                            "id": "6ff51de3-d277-44e2-af77-4b057a469594",
+                            "type": "point",
+                            "x": 2775.8021286602125,
+                            "y": -92.38534556099293
+                        },
+                        {
+                            "id": "df349ddd-05b5-4627-af5c-d9c4b3793b88",
+                            "type": "point",
+                            "x": 2913.4687119094942,
+                            "y": 1.593789280817827
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "29577b31-ec84-45d3-8f14-12f54adf514b": {
+                    "id": "29577b31-ec84-45d3-8f14-12f54adf514b",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "8ba4e1d5-f9d7-4b6f-8e4f-b5fee61041f5",
+                    "sourcePort": "69f117ea-215b-4b61-9dcf-188ad94e60ed",
+                    "target": "c304a0df-a115-4489-8114-73a0c87ae1d0",
+                    "targetPort": "de7c5071-6a9c-4cc7-ab50-f52d579ddecb",
+                    "points": [
+                        {
+                            "id": "a3654d29-fed0-45ad-b110-90acea50373f",
+                            "type": "point",
+                            "x": 2565.614580199498,
+                            "y": -44.552048661716775
+                        },
+                        {
+                            "id": "470a1371-80df-4bdc-a746-5e3652b6f93a",
+                            "type": "point",
+                            "x": 2702.500165733868,
+                            "y": -71.0520378194102
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "3a0a7cc2-092f-4405-b328-8cb47d38e3d1": {
+                    "id": "3a0a7cc2-092f-4405-b328-8cb47d38e3d1",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "937d0ee8-0b35-4305-ae78-e5699ed2170b",
+                    "sourcePort": "00e420dc-04ed-4560-a48f-2625998d1728",
+                    "target": "de10d6e0-4c20-47ff-89d2-826a210270cc",
+                    "targetPort": "20a04b46-243c-4bfd-a2d4-89626b1d565e",
+                    "points": [
+                        {
+                            "id": "ce914b2a-05a1-4b86-92ab-6c9dc76e8d10",
+                            "type": "point",
+                            "x": 1473.0522266805247,
+                            "y": 142.95837561165823
+                        },
+                        {
+                            "id": "568ed311-7566-4d98-ab37-1ebb847789c2",
+                            "type": "point",
+                            "x": 1917.2485572544526,
+                            "y": 138.3063304335353
+                        },
+                        {
+                            "id": "ab79828f-ba80-42ea-9dab-0f52abcbbeda",
+                            "type": "point",
+                            "x": 1915.2370650007356,
+                            "y": -115.14169353478312
+                        },
+                        {
+                            "id": "62a1f9d1-4835-4717-b0a1-fa9e5c278396",
+                            "type": "point",
+                            "x": 1952.219115565637,
+                            "y": -113.29164270304882
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "2c81389b-d70a-487f-93f6-a46829c5cc47": {
+                    "id": "2c81389b-d70a-487f-93f6-a46829c5cc47",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "543b7dc4-3c07-4258-a01c-ce62c7d5e15c",
+                    "sourcePort": "7eee2cae-f738-448a-96e9-1410907a8673",
+                    "target": "de10d6e0-4c20-47ff-89d2-826a210270cc",
+                    "targetPort": "6da7a46d-585e-4ea8-933f-e79647d48b02",
+                    "points": [
+                        {
+                            "id": "22b9f4ba-d609-4885-839a-2fde77677bbd",
+                            "type": "point",
+                            "x": 1889.802242357914,
+                            "y": -175.53121466600155
+                        },
+                        {
+                            "id": "e44b8b72-7815-4df6-8608-687a6546b638",
+                            "type": "point",
+                            "x": 1952.219115565637,
+                            "y": -134.62495044463154
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "849545b6-7d2f-4c6a-9a3d-7c9ad30b3ca1": {
+                    "id": "849545b6-7d2f-4c6a-9a3d-7c9ad30b3ca1",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "de10d6e0-4c20-47ff-89d2-826a210270cc",
+                    "sourcePort": "fba13c01-dfad-4795-bf5b-97619742bc70",
+                    "target": "918d8b81-a46f-4962-800a-1edf2cb6f648",
+                    "targetPort": "7e3daaa1-6916-468d-b31c-384a3d9c0906",
+                    "points": [
+                        {
+                            "id": "6d1ffeb4-91ec-4ef3-beef-f351639563a9",
+                            "type": "point",
+                            "x": 2083.9169211413955,
+                            "y": -134.62495044463154
+                        },
+                        {
+                            "id": "be1d1d17-cc87-46f4-8eef-9a1fca07e798",
+                            "type": "point",
+                            "x": 2146.8855212355184,
+                            "y": -136.22912784982142
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "8b220192-2108-412f-87e3-0bb6c02bed1d": {
+                    "id": "8b220192-2108-412f-87e3-0bb6c02bed1d",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "de10d6e0-4c20-47ff-89d2-826a210270cc",
+                    "sourcePort": "dc09050a-5845-4292-b703-e5cbfa7a7903",
+                    "target": "918d8b81-a46f-4962-800a-1edf2cb6f648",
+                    "targetPort": "7c0745da-6e0b-4f6d-a092-7005ef9c9261",
+                    "points": [
+                        {
+                            "id": "de194cba-ceec-40c9-99fd-f26a76377069",
+                            "type": "point",
+                            "x": 2083.9169211413955,
+                            "y": -113.29164270304882
+                        },
+                        {
+                            "id": "05f6704b-7846-491c-9d29-7ca93fec5311",
+                            "type": "point",
+                            "x": 2146.8855212355184,
+                            "y": -114.89582010823872
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "121f7185-a5b9-4cbe-941f-1b9ceb0890b2": {
+                    "id": "121f7185-a5b9-4cbe-941f-1b9ceb0890b2",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "918d8b81-a46f-4962-800a-1edf2cb6f648",
+                    "sourcePort": "556f6d87-bebb-429b-aefb-7e17b2544394",
+                    "target": "8ba4e1d5-f9d7-4b6f-8e4f-b5fee61041f5",
+                    "targetPort": "205c81ac-4f8a-4ae4-b48a-4154eced6dd2",
+                    "points": [
+                        {
+                            "id": "648358f9-57d5-4cd2-af1c-7aef531b2587",
+                            "type": "point",
+                            "x": 2266.9270853642456,
+                            "y": -136.22912784982142
+                        },
+                        {
+                            "id": "e249651e-b643-4c3d-ba53-3af52a721a79",
+                            "type": "point",
+                            "x": 2319.302107268635,
+                            "y": -108.55205979705866
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "0f56f52f-84dd-4ea7-9983-bbb78c2e3b75": {
+                    "id": "0f56f52f-84dd-4ea7-9983-bbb78c2e3b75",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "918d8b81-a46f-4962-800a-1edf2cb6f648",
+                    "sourcePort": "b4abb070-1777-463a-a2e7-7268b2e76502",
+                    "target": "8ba4e1d5-f9d7-4b6f-8e4f-b5fee61041f5",
+                    "targetPort": "8c9bd8c4-877d-49d0-a51b-a0cd7731918c",
+                    "points": [
+                        {
+                            "id": "ea18031d-c585-4416-a1f8-fc7f6e10ebc9",
+                            "type": "point",
+                            "x": 2266.9270853642456,
+                            "y": -114.89582010823872
+                        },
+                        {
+                            "id": "4554be63-406b-4ed5-b6e9-f745a5da5c71",
+                            "type": "point",
+                            "x": 2319.302107268635,
+                            "y": -67.21874033406345
                         }
                     ],
                     "labels": [],
@@ -1388,7 +1516,7 @@
             }
         },
         {
-            "id": "25982e0b-c0ae-4017-bb2a-ac116a591a02",
+            "id": "13a1de5c-9f01-49b0-ad74-487a6b3965fd",
             "type": "diagram-nodes",
             "isSvg": false,
             "transformed": true,
@@ -1408,8 +1536,8 @@
                             "id": "e291d7e2-8762-45f2-84a7-ebd3af368cd5",
                             "type": "default",
                             "extras": {},
-                            "x": -368.52500156931956,
-                            "y": 50.52496763964774,
+                            "x": -368.395684241429,
+                            "y": 50.39590487856005,
                             "name": "out-0",
                             "alignment": "right",
                             "parentNode": "e2c8f83e-4f69-430a-85ca-6c614531b0a9",
@@ -1430,25 +1558,25 @@
                         "e291d7e2-8762-45f2-84a7-ebd3af368cd5"
                     ]
                 },
-                "e65a7e7a-470d-4c9e-ac6f-7492bef12d0f": {
-                    "id": "e65a7e7a-470d-4c9e-ac6f-7492bef12d0f",
+                "0e04cedc-78e8-4fdf-be41-d1bf075f4c35": {
+                    "id": "0e04cedc-78e8-4fdf-be41-d1bf075f4c35",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
                         "type": "Finish"
                     },
-                    "x": 1847.8331480869745,
-                    "y": -109.12088922357623,
+                    "x": 1821.9923169240424,
+                    "y": -398.53819824841514,
                     "ports": [
                         {
-                            "id": "e6ba1834-ece7-4194-b1a5-0bb1c0bdc4b8",
+                            "id": "930b7e5d-cc38-4088-8bea-543b20985257",
                             "type": "default",
                             "extras": {},
-                            "x": 1848.625116593871,
-                            "y": -82.31250105578259,
+                            "x": 1822.6564824909756,
+                            "y": -371.864566591815,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "e65a7e7a-470d-4c9e-ac6f-7492bef12d0f",
+                            "parentNode": "0e04cedc-78e8-4fdf-be41-d1bf075f4c35",
                             "links": [
                                 "407b43be-81b2-48ec-a06d-a68833c1d539"
                             ],
@@ -1459,14 +1587,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "fca768c6-8846-4797-a028-acac114c8735",
+                            "id": "de4068ae-a62b-4ffa-91aa-1713025ada80",
                             "type": "default",
                             "extras": {},
-                            "x": 1848.625116593871,
-                            "y": -60.71249098798128,
+                            "x": 1822.6564824909756,
+                            "y": -350.5312148949354,
                             "name": "parameter-dynalist-outputs",
                             "alignment": "left",
-                            "parentNode": "e65a7e7a-470d-4c9e-ac6f-7492bef12d0f",
+                            "parentNode": "0e04cedc-78e8-4fdf-be41-d1bf075f4c35",
                             "links": [],
                             "in": true,
                             "label": "outputs",
@@ -1483,13 +1611,13 @@
                     "name": "Finish",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [
-                        "e6ba1834-ece7-4194-b1a5-0bb1c0bdc4b8",
-                        "fca768c6-8846-4797-a028-acac114c8735"
+                        "930b7e5d-cc38-4088-8bea-543b20985257",
+                        "de4068ae-a62b-4ffa-91aa-1713025ada80"
                     ],
                     "portsOutOrder": []
                 },
-                "1b390e88-7605-46bd-b2fa-3082dff9b8b6": {
-                    "id": "1b390e88-7605-46bd-b2fa-3082dff9b8b6",
+                "5bdc1739-622e-4274-9392-55ca06ae5ac4": {
+                    "id": "5bdc1739-622e-4274-9392-55ca06ae5ac4",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -1507,14 +1635,14 @@
                     "y": 23.95055694736307,
                     "ports": [
                         {
-                            "id": "8e9b1c61-6d1a-4017-95f7-78500b806ccd",
+                            "id": "fdb0623e-0cdd-48c6-aaaa-1c11e667bcce",
                             "type": "default",
                             "extras": {},
-                            "x": 4.512587558370319,
-                            "y": 50.749967744520674,
+                            "x": 4.3752986986411955,
+                            "y": 50.61462643582003,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "1b390e88-7605-46bd-b2fa-3082dff9b8b6",
+                            "parentNode": "5bdc1739-622e-4274-9392-55ca06ae5ac4",
                             "links": [
                                 "fd5bdc78-bc64-452c-81cf-e11240304c10"
                             ],
@@ -1525,14 +1653,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "f6672a3e-cd42-43a4-8833-d349abb7f08a",
+                            "id": "da530efb-1193-424d-91e5-5ddedb5ed2d3",
                             "type": "default",
                             "extras": {},
-                            "x": 162.63739854874834,
-                            "y": 50.749967744520674,
+                            "x": 162.770848312743,
+                            "y": 50.61462643582003,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "1b390e88-7605-46bd-b2fa-3082dff9b8b6",
+                            "parentNode": "5bdc1739-622e-4274-9392-55ca06ae5ac4",
                             "links": [
                                 "1fa0339c-bd91-423e-b9dc-c0d0e78d212e"
                             ],
@@ -1543,14 +1671,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "6cb78613-6553-452b-9bdf-c0b2d6a53105",
+                            "id": "74d277e6-ec5d-4486-aefd-c0f58d1ad6f9",
                             "type": "default",
                             "extras": {},
-                            "x": 162.63739854874834,
-                            "y": 72.34997781232198,
+                            "x": 162.770848312743,
+                            "y": 71.94793417740274,
                             "name": "parameter-out-Memory-memory",
                             "alignment": "right",
-                            "parentNode": "1b390e88-7605-46bd-b2fa-3082dff9b8b6",
+                            "parentNode": "5bdc1739-622e-4274-9392-55ca06ae5ac4",
                             "links": [
                                 "acaf4f91-8afe-4639-a76f-450e5997e6bf"
                             ],
@@ -1562,17 +1690,17 @@
                         }
                     ],
                     "name": "AgentNumpyMemory",
-                    "color": "rgb(153,0,102)",
+                    "color": "rgb(255,102,0)",
                     "portsInOrder": [
-                        "8e9b1c61-6d1a-4017-95f7-78500b806ccd"
+                        "fdb0623e-0cdd-48c6-aaaa-1c11e667bcce"
                     ],
                     "portsOutOrder": [
-                        "f6672a3e-cd42-43a4-8833-d349abb7f08a",
-                        "6cb78613-6553-452b-9bdf-c0b2d6a53105"
+                        "da530efb-1193-424d-91e5-5ddedb5ed2d3",
+                        "74d277e6-ec5d-4486-aefd-c0f58d1ad6f9"
                     ]
                 },
-                "86136d09-eadb-4670-ac4a-511aac5b558b": {
-                    "id": "86136d09-eadb-4670-ac4a-511aac5b558b",
+                "721bfc7c-4461-49ce-8352-0ff5e5dd3afb": {
+                    "id": "721bfc7c-4461-49ce-8352-0ff5e5dd3afb",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -1590,14 +1718,14 @@
                     "y": 22.375733417007098,
                     "ports": [
                         {
-                            "id": "4cb39670-0ab8-45b6-ad1b-8f83f188e8f7",
+                            "id": "a8a0b557-78ee-40be-9b4d-29610accd303",
                             "type": "default",
                             "extras": {},
-                            "x": -215.7374981514154,
-                            "y": 49.174967010410164,
+                            "x": -215.87484796553272,
+                            "y": 49.041730092373264,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "86136d09-eadb-4670-ac4a-511aac5b558b",
+                            "parentNode": "721bfc7c-4461-49ce-8352-0ff5e5dd3afb",
                             "links": [
                                 "ee39f2f1-807f-49f1-953d-2b98cdcff051"
                             ],
@@ -1608,14 +1736,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "b63dade7-d999-49e6-a7a9-929dafaa089b",
+                            "id": "5f110ee5-6472-4142-addf-288e07696d36",
                             "type": "default",
                             "extras": {},
-                            "x": -215.7374981514154,
-                            "y": 70.77497707821146,
+                            "x": -215.87484796553272,
+                            "y": 70.37503783395597,
                             "name": "parameter-secret-organization",
                             "alignment": "left",
-                            "parentNode": "86136d09-eadb-4670-ac4a-511aac5b558b",
+                            "parentNode": "721bfc7c-4461-49ce-8352-0ff5e5dd3afb",
                             "links": [],
                             "in": true,
                             "label": "organization",
@@ -1624,14 +1752,14 @@
                             "dataType": "secret"
                         },
                         {
-                            "id": "2be27f6f-e17c-4bbc-bbad-cd4123137052",
+                            "id": "84aaa69e-7e95-4cea-989f-717f31656182",
                             "type": "default",
                             "extras": {},
-                            "x": -215.7374981514154,
-                            "y": 92.37498714601277,
+                            "x": -215.87484796553272,
+                            "y": 91.70834557553869,
                             "name": "parameter-string-base_url",
                             "alignment": "left",
-                            "parentNode": "86136d09-eadb-4670-ac4a-511aac5b558b",
+                            "parentNode": "721bfc7c-4461-49ce-8352-0ff5e5dd3afb",
                             "links": [],
                             "in": true,
                             "label": "base_url",
@@ -1640,16 +1768,16 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "18debe53-c0d6-41a1-b1d5-93e639f37988",
+                            "id": "f48016e4-5b53-4aae-b061-cb98076cc452",
                             "type": "default",
                             "extras": {},
-                            "x": -215.7374981514154,
-                            "y": 113.97492094259208,
+                            "x": -215.87484796553272,
+                            "y": 113.04169727241828,
                             "name": "parameter-secret-api_key",
                             "alignment": "left",
-                            "parentNode": "86136d09-eadb-4670-ac4a-511aac5b558b",
+                            "parentNode": "721bfc7c-4461-49ce-8352-0ff5e5dd3afb",
                             "links": [
-                                "0cc96856-42f8-4d89-83e0-9f53fe3ed0ca"
+                                "a7ce3ded-ad54-4dce-8010-54a5fa121b9c"
                             ],
                             "in": true,
                             "label": "api_key",
@@ -1658,17 +1786,15 @@
                             "dataType": "secret"
                         },
                         {
-                            "id": "ce868769-0dae-478b-a5f8-d96c29b95d55",
+                            "id": "2965ddbd-051c-474e-82a8-9f45dbf1d2e7",
                             "type": "default",
                             "extras": {},
-                            "x": -215.7374981514154,
-                            "y": 135.57493101039339,
+                            "x": -215.87484796553272,
+                            "y": 134.37504896929786,
                             "name": "parameter-boolean-from_env",
                             "alignment": "left",
-                            "parentNode": "86136d09-eadb-4670-ac4a-511aac5b558b",
-                            "links": [
-                                "3150865e-b75b-484b-97ed-6bedf5817401"
-                            ],
+                            "parentNode": "721bfc7c-4461-49ce-8352-0ff5e5dd3afb",
+                            "links": [],
                             "in": true,
                             "label": "from_env",
                             "varName": "from_env",
@@ -1676,14 +1802,14 @@
                             "dataType": "boolean"
                         },
                         {
-                            "id": "ee9823ad-cee8-4dbd-9b7a-86576b7c6e19",
+                            "id": "0f0a0e38-e5bf-4411-8589-ff0c39d5391d",
                             "type": "default",
                             "extras": {},
-                            "x": -77.55006086066072,
-                            "y": 49.174967010410164,
+                            "x": -77.41654190890306,
+                            "y": 49.041730092373264,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "86136d09-eadb-4670-ac4a-511aac5b558b",
+                            "parentNode": "721bfc7c-4461-49ce-8352-0ff5e5dd3afb",
                             "links": [
                                 "fd5bdc78-bc64-452c-81cf-e11240304c10"
                             ],
@@ -1695,20 +1821,20 @@
                         }
                     ],
                     "name": "OpenAIAuthorize",
-                    "color": "rgb(102,102,102)",
+                    "color": "rgb(255,102,0)",
                     "portsInOrder": [
-                        "4cb39670-0ab8-45b6-ad1b-8f83f188e8f7",
-                        "b63dade7-d999-49e6-a7a9-929dafaa089b",
-                        "2be27f6f-e17c-4bbc-bbad-cd4123137052",
-                        "18debe53-c0d6-41a1-b1d5-93e639f37988",
-                        "ce868769-0dae-478b-a5f8-d96c29b95d55"
+                        "a8a0b557-78ee-40be-9b4d-29610accd303",
+                        "5f110ee5-6472-4142-addf-288e07696d36",
+                        "84aaa69e-7e95-4cea-989f-717f31656182",
+                        "f48016e4-5b53-4aae-b061-cb98076cc452",
+                        "2965ddbd-051c-474e-82a8-9f45dbf1d2e7"
                     ],
                     "portsOutOrder": [
-                        "ee9823ad-cee8-4dbd-9b7a-86576b7c6e19"
+                        "0f0a0e38-e5bf-4411-8589-ff0c39d5391d"
                     ]
                 },
-                "1a4d5743-141a-4ecf-ba8f-6cf4ba870fbc": {
-                    "id": "1a4d5743-141a-4ecf-ba8f-6cf4ba870fbc",
+                "e3584bf6-9116-4b87-9afb-4612ef90965b": {
+                    "id": "e3584bf6-9116-4b87-9afb-4612ef90965b",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -1719,14 +1845,14 @@
                     "y": 210.9192157780686,
                     "ports": [
                         {
-                            "id": "62d882d1-954f-4837-9e1b-ef991a85a5e1",
+                            "id": "56162e56-a683-44d1-9fd7-f5387fcfb50e",
                             "type": "default",
                             "extras": {},
-                            "x": 242.12503623368139,
-                            "y": 234.71251273569766,
+                            "x": 184.57242668312284,
+                            "y": 210.9192157780686,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "1a4d5743-141a-4ecf-ba8f-6cf4ba870fbc",
+                            "parentNode": "e3584bf6-9116-4b87-9afb-4612ef90965b",
                             "links": [
                                 "59948ccc-8d0d-4104-ad20-4757522ddb7b"
                             ],
@@ -1741,11 +1867,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "62d882d1-954f-4837-9e1b-ef991a85a5e1"
+                        "56162e56-a683-44d1-9fd7-f5387fcfb50e"
                     ]
                 },
-                "f0caf0ac-2116-427d-b92c-641343b1f5e0": {
-                    "id": "f0caf0ac-2116-427d-b92c-641343b1f5e0",
+                "ae99a1db-ec89-482c-85e3-c0d8bad3036c": {
+                    "id": "ae99a1db-ec89-482c-85e3-c0d8bad3036c",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -1756,14 +1882,14 @@
                     "y": 272.45684153184425,
                     "ports": [
                         {
-                            "id": "0bbef686-ba5c-4e13-a02a-1c9013d5d9b7",
+                            "id": "09b66859-ec10-4dcc-bded-055111197ced",
                             "type": "default",
                             "extras": {},
                             "x": 818.1899540562206,
                             "y": 272.45684153184425,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "f0caf0ac-2116-427d-b92c-641343b1f5e0",
+                            "parentNode": "ae99a1db-ec89-482c-85e3-c0d8bad3036c",
                             "links": [
                                 "2c55f47c-f510-420c-bbfb-df5fd16bce7c",
                                 "44806538-bd83-41d4-9d83-4a7ac59af827"
@@ -1779,11 +1905,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "0bbef686-ba5c-4e13-a02a-1c9013d5d9b7"
+                        "09b66859-ec10-4dcc-bded-055111197ced"
                     ]
                 },
-                "440175cf-ff96-4109-8c7a-ad7a3525341a": {
-                    "id": "440175cf-ff96-4109-8c7a-ad7a3525341a",
+                "ab1b9d01-b445-4f3c-8f7d-35aa6bbe1cc9": {
+                    "id": "ab1b9d01-b445-4f3c-8f7d-35aa6bbe1cc9",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -1794,14 +1920,14 @@
                     "y": 300.16272463213,
                     "ports": [
                         {
-                            "id": "802f1409-2866-437d-a149-cde28d41a579",
+                            "id": "606f534f-e0ea-4554-9f7c-5c173f8e414b",
                             "type": "default",
                             "extras": {},
-                            "x": 315.9125021737359,
-                            "y": 323.9625418296128,
+                            "x": 258.35719478935033,
+                            "y": 300.16272463213,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "440175cf-ff96-4109-8c7a-ad7a3525341a",
+                            "parentNode": "ab1b9d01-b445-4f3c-8f7d-35aa6bbe1cc9",
                             "links": [
                                 "6e6ceca9-1911-4e82-a8c0-c62abb44bd97"
                             ],
@@ -1816,29 +1942,29 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "802f1409-2866-437d-a149-cde28d41a579"
+                        "606f534f-e0ea-4554-9f7c-5c173f8e414b"
                     ]
                 },
-                "31edd7f8-b1f3-4d7f-a801-74c948bfeb46": {
-                    "id": "31edd7f8-b1f3-4d7f-a801-74c948bfeb46",
+                "e08c1960-78ff-47fa-aba3-015199fe609b": {
+                    "id": "e08c1960-78ff-47fa-aba3-015199fe609b",
                     "type": "custom-node",
-                    "selected": true,
+                    "selected": false,
                     "extras": {
                         "type": "int",
-                        "attached": false
+                        "attached": true
                     },
-                    "x": 681.7950979948454,
-                    "y": 702.9285334234278,
+                    "x": 670.8290504564166,
+                    "y": 744.9650489874051,
                     "ports": [
                         {
-                            "id": "40ec3b83-05fb-4deb-859d-fdd5d717c3b1",
+                            "id": "a9de5979-20c0-4a9a-a4a2-08e6eaa99f05",
                             "type": "default",
                             "extras": {},
-                            "x": 745.2687550528879,
-                            "y": 726.7250285803541,
+                            "x": 670.8290504564166,
+                            "y": 744.9650489874051,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "31edd7f8-b1f3-4d7f-a801-74c948bfeb46",
+                            "parentNode": "e08c1960-78ff-47fa-aba3-015199fe609b",
                             "links": [
                                 "3bcb0615-0fd9-4c36-80a3-1d960540b388"
                             ],
@@ -1853,11 +1979,11 @@
                     "color": "blue",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "40ec3b83-05fb-4deb-859d-fdd5d717c3b1"
+                        "a9de5979-20c0-4a9a-a4a2-08e6eaa99f05"
                     ]
                 },
-                "5c9150f1-227a-4874-944d-e5a25f48ac40": {
-                    "id": "5c9150f1-227a-4874-944d-e5a25f48ac40",
+                "af98eb68-6175-4090-92a6-bd1e49333095": {
+                    "id": "af98eb68-6175-4090-92a6-bd1e49333095",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -1875,14 +2001,14 @@
                     "y": 918.8702157780685,
                     "ports": [
                         {
-                            "id": "f3bf6daa-c758-4cb0-bcad-d2f49a1434a9",
+                            "id": "5b5be0d2-359d-4397-a20e-8b0347ef204d",
                             "type": "default",
                             "extras": {},
-                            "x": -126.18753268321116,
-                            "y": 945.6625246952888,
+                            "x": -126.32278760494691,
+                            "y": 945.531372173182,
                             "name": "parameter-string-tool_name",
                             "alignment": "left",
-                            "parentNode": "5c9150f1-227a-4874-944d-e5a25f48ac40",
+                            "parentNode": "af98eb68-6175-4090-92a6-bd1e49333095",
                             "links": [
                                 "aad5e35e-a48f-4ea3-9866-2d8df4183fc1"
                             ],
@@ -1893,14 +2019,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "1b69180f-8bfc-4337-a2d2-99220c80d498",
+                            "id": "bc318865-a866-48e1-a6ee-655d6115d95a",
                             "type": "default",
                             "extras": {},
-                            "x": -126.18753268321116,
-                            "y": 967.2625347630901,
+                            "x": -126.32278760494691,
+                            "y": 966.8646359594678,
                             "name": "parameter-string-description",
                             "alignment": "left",
-                            "parentNode": "5c9150f1-227a-4874-944d-e5a25f48ac40",
+                            "parentNode": "af98eb68-6175-4090-92a6-bd1e49333095",
                             "links": [
                                 "5b230e36-c8f1-4be2-94c9-6a5dbfcbc442"
                             ],
@@ -1911,14 +2037,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "02191e3a-128b-4a12-a8d1-19d102a8e651",
+                            "id": "5b01c091-6ad3-44db-9027-810342076eff",
                             "type": "default",
                             "extras": {},
-                            "x": -126.18753268321116,
-                            "y": 988.8625448308914,
+                            "x": -126.32278760494691,
+                            "y": 988.1980755669412,
                             "name": "parameter-string-for_toolbelt",
                             "alignment": "left",
-                            "parentNode": "5c9150f1-227a-4874-944d-e5a25f48ac40",
+                            "parentNode": "af98eb68-6175-4090-92a6-bd1e49333095",
                             "links": [
                                 "e31af8e8-9442-41d4-b9de-f1bdddfefdc4"
                             ],
@@ -1929,14 +2055,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "d3305da6-e57f-47fc-8a9c-44f115daa55f",
+                            "id": "d634d75a-3bd5-4758-a30a-28d7bcc3e153",
                             "type": "default",
                             "extras": {},
-                            "x": 34.12496576752965,
-                            "y": 945.6625246952888,
+                            "x": 34.08345310949663,
+                            "y": 945.531372173182,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "5c9150f1-227a-4874-944d-e5a25f48ac40",
+                            "parentNode": "af98eb68-6175-4090-92a6-bd1e49333095",
                             "links": [
                                 "90ec14ef-f1d7-48bf-b1a6-97788d305dc7"
                             ],
@@ -1947,14 +2073,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "17720eff-f3f5-4735-9cdc-2e6f2652d05a",
+                            "id": "5f8a106f-0556-4e7a-a5f8-024426e9dd2e",
                             "type": "default",
                             "extras": {},
-                            "x": 34.12496576752965,
-                            "y": 967.2625347630901,
+                            "x": 34.08345310949663,
+                            "y": 966.8646359594678,
                             "name": "parameter-out-string-tool_input",
                             "alignment": "right",
-                            "parentNode": "5c9150f1-227a-4874-944d-e5a25f48ac40",
+                            "parentNode": "af98eb68-6175-4090-92a6-bd1e49333095",
                             "links": [],
                             "in": false,
                             "label": "tool_input",
@@ -1966,17 +2092,17 @@
                     "name": "AgentDefineTool",
                     "color": "red",
                     "portsInOrder": [
-                        "f3bf6daa-c758-4cb0-bcad-d2f49a1434a9",
-                        "1b69180f-8bfc-4337-a2d2-99220c80d498",
-                        "02191e3a-128b-4a12-a8d1-19d102a8e651"
+                        "5b5be0d2-359d-4397-a20e-8b0347ef204d",
+                        "bc318865-a866-48e1-a6ee-655d6115d95a",
+                        "5b01c091-6ad3-44db-9027-810342076eff"
                     ],
                     "portsOutOrder": [
-                        "d3305da6-e57f-47fc-8a9c-44f115daa55f",
-                        "17720eff-f3f5-4735-9cdc-2e6f2652d05a"
+                        "d634d75a-3bd5-4758-a30a-28d7bcc3e153",
+                        "5f8a106f-0556-4e7a-a5f8-024426e9dd2e"
                     ]
                 },
-                "65dfa2a6-1226-4d58-9f1f-535aa4d14b9f": {
-                    "id": "65dfa2a6-1226-4d58-9f1f-535aa4d14b9f",
+                "a7714b3b-0162-4f09-88a7-24cf336046f3": {
+                    "id": "a7714b3b-0162-4f09-88a7-24cf336046f3",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -1987,14 +2113,14 @@
                     "y": 867.5395804873501,
                     "ports": [
                         {
-                            "id": "25ed948c-d045-42b1-80e3-fb6a3868adc1",
+                            "id": "4851e4f2-c0ab-41d7-bfe1-6c4ab0d81335",
                             "type": "default",
                             "extras": {},
-                            "x": -324.5250488574772,
-                            "y": 891.3375459844937,
+                            "x": -324.6561199614959,
+                            "y": 891.864592004171,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "65dfa2a6-1226-4d58-9f1f-535aa4d14b9f",
+                            "parentNode": "a7714b3b-0162-4f09-88a7-24cf336046f3",
                             "links": [
                                 "aad5e35e-a48f-4ea3-9866-2d8df4183fc1"
                             ],
@@ -2009,11 +2135,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "25ed948c-d045-42b1-80e3-fb6a3868adc1"
+                        "4851e4f2-c0ab-41d7-bfe1-6c4ab0d81335"
                     ]
                 },
-                "01f7badd-faea-4c35-8600-530e2a6ee92e": {
-                    "id": "01f7badd-faea-4c35-8600-530e2a6ee92e",
+                "4ca44a22-f05f-4cd3-a416-2eb92f81f25e": {
+                    "id": "4ca44a22-f05f-4cd3-a416-2eb92f81f25e",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -2024,14 +2150,14 @@
                     "y": 939.5552510719973,
                     "ports": [
                         {
-                            "id": "9280b2e5-8028-4fcf-bbe2-8397a03ba259",
+                            "id": "9ede1ed4-5871-49ed-b400-5f87f80b8e5f",
                             "type": "default",
                             "extras": {},
-                            "x": -319.83749582514315,
-                            "y": 963.3500117530158,
+                            "x": -319.979100552595,
+                            "y": 963.885521758332,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "01f7badd-faea-4c35-8600-530e2a6ee92e",
+                            "parentNode": "4ca44a22-f05f-4cd3-a416-2eb92f81f25e",
                             "links": [
                                 "5b230e36-c8f1-4be2-94c9-6a5dbfcbc442"
                             ],
@@ -2046,11 +2172,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "9280b2e5-8028-4fcf-bbe2-8397a03ba259"
+                        "9ede1ed4-5871-49ed-b400-5f87f80b8e5f"
                     ]
                 },
-                "98803083-f227-4fab-9927-755a8992e8ff": {
-                    "id": "98803083-f227-4fab-9927-755a8992e8ff",
+                "7f835863-6e95-4f2a-93e2-8a71f175d9e8": {
+                    "id": "7f835863-6e95-4f2a-93e2-8a71f175d9e8",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -2061,14 +2187,14 @@
                     "y": 996.0355334234279,
                     "ports": [
                         {
-                            "id": "c002447a-786c-4210-8d1c-282aff2f9f0f",
+                            "id": "fcc1b3c6-94d1-416c-bcc5-5b95fd9e30bd",
                             "type": "default",
                             "extras": {},
-                            "x": -321.10001336275724,
-                            "y": 1019.8249999405103,
+                            "x": -320.96862219589013,
+                            "y": 1020.3645618215338,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "98803083-f227-4fab-9927-755a8992e8ff",
+                            "parentNode": "7f835863-6e95-4f2a-93e2-8a71f175d9e8",
                             "links": [
                                 "e31af8e8-9442-41d4-b9de-f1bdddfefdc4"
                             ],
@@ -2083,11 +2209,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "c002447a-786c-4210-8d1c-282aff2f9f0f"
+                        "fcc1b3c6-94d1-416c-bcc5-5b95fd9e30bd"
                     ]
                 },
-                "bf0d4fb0-2d55-4e0c-87a6-adfd6bcd4ab4": {
-                    "id": "bf0d4fb0-2d55-4e0c-87a6-adfd6bcd4ab4",
+                "0864f0a0-0dc9-48b6-9348-18db03339de7": {
+                    "id": "0864f0a0-0dc9-48b6-9348-18db03339de7",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -2105,14 +2231,14 @@
                     "y": 921.8702157780685,
                     "ports": [
                         {
-                            "id": "15d2c91a-eb18-45a5-acec-4cc048bef3ad",
+                            "id": "bf5c22de-dd46-45ae-8151-c5091aba8e45",
                             "type": "default",
                             "extras": {},
-                            "x": 178.8000332008238,
-                            "y": 948.6625769410758,
+                            "x": 178.66684187534327,
+                            "y": 948.5314090956314,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "bf0d4fb0-2d55-4e0c-87a6-adfd6bcd4ab4",
+                            "parentNode": "0864f0a0-0dc9-48b6-9348-18db03339de7",
                             "links": [
                                 "90ec14ef-f1d7-48bf-b1a6-97788d305dc7"
                             ],
@@ -2123,14 +2249,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "0bd462dc-910e-4fe6-8b55-4c86ca241980",
+                            "id": "482c7a6f-8cd7-4b0f-9ec6-88da5c6f243f",
                             "type": "default",
                             "extras": {},
-                            "x": 311.25004408854073,
-                            "y": 948.6625769410758,
+                            "x": 311.39601453702403,
+                            "y": 948.5314090956314,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "bf0d4fb0-2d55-4e0c-87a6-adfd6bcd4ab4",
+                            "parentNode": "0864f0a0-0dc9-48b6-9348-18db03339de7",
                             "links": [
                                 "37f942b9-d1eb-4637-a87b-7928d63a8813"
                             ],
@@ -2141,14 +2267,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "4830442b-d8eb-4705-8d3a-f6ccbd5f4609",
+                            "id": "e2726af5-570a-478a-b4b3-f890c012ae05",
                             "type": "default",
                             "extras": {},
-                            "x": 311.25004408854073,
-                            "y": 970.2625107376551,
+                            "x": 311.39601453702403,
+                            "y": 969.8646728819172,
                             "name": "parameter-out-string-time_str",
                             "alignment": "right",
-                            "parentNode": "bf0d4fb0-2d55-4e0c-87a6-adfd6bcd4ab4",
+                            "parentNode": "0864f0a0-0dc9-48b6-9348-18db03339de7",
                             "links": [
                                 "085de563-29ca-466a-9ac7-055026ef2d39"
                             ],
@@ -2162,15 +2288,15 @@
                     "name": "GetCurrentTime",
                     "color": "rgb(255,204,204)",
                     "portsInOrder": [
-                        "15d2c91a-eb18-45a5-acec-4cc048bef3ad"
+                        "bf5c22de-dd46-45ae-8151-c5091aba8e45"
                     ],
                     "portsOutOrder": [
-                        "0bd462dc-910e-4fe6-8b55-4c86ca241980",
-                        "4830442b-d8eb-4705-8d3a-f6ccbd5f4609"
+                        "482c7a6f-8cd7-4b0f-9ec6-88da5c6f243f",
+                        "e2726af5-570a-478a-b4b3-f890c012ae05"
                     ]
                 },
-                "614ef7c7-82c6-4966-a89f-10c6caa99f7d": {
-                    "id": "614ef7c7-82c6-4966-a89f-10c6caa99f7d",
+                "c052005b-71c6-4471-a7b0-1d1c8d9c5915": {
+                    "id": "c052005b-71c6-4471-a7b0-1d1c8d9c5915",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -2188,14 +2314,14 @@
                     "y": 921.3114478526526,
                     "ports": [
                         {
-                            "id": "db714b1a-6ca5-4b06-a0ac-44ed8618bc53",
+                            "id": "aa04a2e3-2ad1-4b97-bbde-548f62246c22",
                             "type": "default",
                             "extras": {},
-                            "x": 449.4624983401084,
-                            "y": 948.1000385432825,
+                            "x": 449.3333624150674,
+                            "y": 947.9687812956057,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "614ef7c7-82c6-4966-a89f-10c6caa99f7d",
+                            "parentNode": "c052005b-71c6-4471-a7b0-1d1c8d9c5915",
                             "links": [
                                 "37f942b9-d1eb-4637-a87b-7928d63a8813"
                             ],
@@ -2206,14 +2332,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "0de4606f-623a-404c-82a1-d21ea8c6b781",
+                            "id": "81c0475d-b3d2-4986-97e4-aa1cf0282a54",
                             "type": "default",
                             "extras": {},
-                            "x": 449.4624983401084,
-                            "y": 969.7000486110838,
+                            "x": 449.3333624150674,
+                            "y": 969.302220903079,
                             "name": "parameter-dynalist-results",
                             "alignment": "left",
-                            "parentNode": "614ef7c7-82c6-4966-a89f-10c6caa99f7d",
+                            "parentNode": "c052005b-71c6-4471-a7b0-1d1c8d9c5915",
                             "links": [
                                 "085de563-29ca-466a-9ac7-055026ef2d39"
                             ],
@@ -2225,18 +2351,18 @@
                             "dynaPortOrder": 0,
                             "dynaPortRef": {
                                 "previous": null,
-                                "next": "6e6d98f1-20d5-4e93-b21f-c94fb4e0df63"
+                                "next": "16983f14-fda6-4e1c-be22-08af9e7d0f61"
                             }
                         },
                         {
-                            "id": "6e6d98f1-20d5-4e93-b21f-c94fb4e0df63",
+                            "id": "16983f14-fda6-4e1c-be22-08af9e7d0f61",
                             "type": "default",
                             "extras": {},
-                            "x": 449.4624983401084,
-                            "y": 991.3000586788851,
+                            "x": 449.3333624150674,
+                            "y": 990.6354846893648,
                             "name": "parameter-dynalist-results-1",
                             "alignment": "left",
-                            "parentNode": "614ef7c7-82c6-4966-a89f-10c6caa99f7d",
+                            "parentNode": "c052005b-71c6-4471-a7b0-1d1c8d9c5915",
                             "links": [],
                             "in": true,
                             "label": "results[1]",
@@ -2245,19 +2371,19 @@
                             "dataType": "dynalist",
                             "dynaPortOrder": 1,
                             "dynaPortRef": {
-                                "previous": "0de4606f-623a-404c-82a1-d21ea8c6b781",
+                                "previous": "81c0475d-b3d2-4986-97e4-aa1cf0282a54",
                                 "next": null
                             }
                         },
                         {
-                            "id": "40fdeda7-c7d5-48e8-ae19-d3eb9939590b",
+                            "id": "e6492c8b-602e-4321-ac75-64613f8ce8ba",
                             "type": "default",
                             "extras": {},
-                            "x": 585.8249178310666,
-                            "y": 948.1000385432825,
+                            "x": 585.9481833206755,
+                            "y": 947.9687812956057,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "614ef7c7-82c6-4966-a89f-10c6caa99f7d",
+                            "parentNode": "c052005b-71c6-4471-a7b0-1d1c8d9c5915",
                             "links": [],
                             "in": false,
                             "label": "▶",
@@ -2269,79 +2395,42 @@
                     "name": "AgentToolOutput",
                     "color": "red",
                     "portsInOrder": [
-                        "db714b1a-6ca5-4b06-a0ac-44ed8618bc53",
-                        "0de4606f-623a-404c-82a1-d21ea8c6b781",
-                        "6e6d98f1-20d5-4e93-b21f-c94fb4e0df63"
+                        "aa04a2e3-2ad1-4b97-bbde-548f62246c22",
+                        "81c0475d-b3d2-4986-97e4-aa1cf0282a54",
+                        "16983f14-fda6-4e1c-be22-08af9e7d0f61"
                     ],
                     "portsOutOrder": [
-                        "40fdeda7-c7d5-48e8-ae19-d3eb9939590b"
+                        "e6492c8b-602e-4321-ac75-64613f8ce8ba"
                     ]
                 },
-                "0d95013e-fcd1-432a-a34a-b152dfed1750": {
-                    "id": "0d95013e-fcd1-432a-a34a-b152dfed1750",
-                    "type": "custom-node",
-                    "selected": false,
-                    "extras": {
-                        "type": "boolean",
-                        "attached": false
-                    },
-                    "x": -421.8294554796305,
-                    "y": 326.08609243512285,
-                    "ports": [
-                        {
-                            "id": "ba89445c-6a8a-45f9-8bbb-326765285e8d",
-                            "type": "default",
-                            "extras": {},
-                            "x": -352.22500244643857,
-                            "y": 349.87502242145297,
-                            "name": "out-0",
-                            "alignment": "right",
-                            "parentNode": "0d95013e-fcd1-432a-a34a-b152dfed1750",
-                            "links": [
-                                "3150865e-b75b-484b-97ed-6bedf5817401"
-                            ],
-                            "in": false,
-                            "label": "False",
-                            "varName": "False",
-                            "portType": "",
-                            "dataType": "boolean"
-                        }
-                    ],
-                    "name": "Literal Boolean",
-                    "color": "red",
-                    "portsInOrder": [],
-                    "portsOutOrder": [
-                        "ba89445c-6a8a-45f9-8bbb-326765285e8d"
-                    ]
-                },
-                "3cc38dc4-6215-4bfb-becf-9c1cbefc4eb5": {
-                    "id": "3cc38dc4-6215-4bfb-becf-9c1cbefc4eb5",
+                "86117b35-2c6d-4e17-a963-3778daf93a53": {
+                    "id": "86117b35-2c6d-4e17-a963-3778daf93a53",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
                         "type": "library_component",
                         "path": "xai_components/xai_gradio/gradio_component.py",
-                        "description": "Launches a Gradio Interface or Block\n\n##### inPorts:\n- app (Interface | Block): interface or block to launch",
+                        "description": "Launches a Gradio Interface or Block.\n\n##### inPorts:\n- app (Interface | Block): Gradio Interface or Block to launch.",
                         "lineNo": [
                             {
-                                "lineno": 101,
-                                "end_lineno": 110
+                                "lineno": 183,
+                                "end_lineno": 192
                             }
                         ],
                         "nextNode": "None"
                     },
-                    "x": 1604.606887073061,
-                    "y": -107.50142504867696,
+                    "x": 1623.5568299258778,
+                    "y": -317.673518507191,
                     "ports": [
                         {
-                            "id": "9d6a86b4-93fd-4efc-9598-a6c7c7d6adc7",
+                            "id": "61e2966b-e05f-4d76-a2b0-cd595d2d8074",
                             "type": "default",
                             "extras": {},
-                            "x": 1605.4001557686777,
-                            "y": -80.69997488045259,
+                            "x": 1624.2190639914218,
+                            "y": -290.99998494953957,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "3cc38dc4-6215-4bfb-becf-9c1cbefc4eb5",
+                            "parentNode": "86117b35-2c6d-4e17-a963-3778daf93a53",
                             "links": [
                                 "dd6192f3-1f15-426b-9ecd-e030767446b1"
                             ],
@@ -2352,14 +2441,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "36c49ac2-a5e7-4175-adc6-cf9a63c41ebb",
+                            "id": "e421943f-21f9-4edc-8c1a-b41733314d7f",
                             "type": "default",
                             "extras": {},
-                            "x": 1605.4001557686777,
-                            "y": -59.09996481265129,
+                            "x": 1624.2190639914218,
+                            "y": -269.6666112750116,
                             "name": "parameter-gr.Blocks-app",
                             "alignment": "left",
-                            "parentNode": "3cc38dc4-6215-4bfb-becf-9c1cbefc4eb5",
+                            "parentNode": "86117b35-2c6d-4e17-a963-3778daf93a53",
                             "links": [
                                 "66bb0c96-c605-418b-94bc-df1adba9c3fb"
                             ],
@@ -2370,14 +2459,14 @@
                             "dataType": "gr.Blocks"
                         },
                         {
-                            "id": "aa6f6d0c-fcaf-4c2b-8b71-987bdffd12a1",
+                            "id": "d0e34393-06d9-4e68-8eda-4c6f795fed8f",
                             "type": "default",
                             "extras": {},
-                            "x": 1727.7126534567062,
-                            "y": -80.69997488045259,
+                            "x": 1746.8022992067647,
+                            "y": -290.99998494953957,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "3cc38dc4-6215-4bfb-becf-9c1cbefc4eb5",
+                            "parentNode": "86117b35-2c6d-4e17-a963-3778daf93a53",
                             "links": [
                                 "407b43be-81b2-48ec-a06d-a68833c1d539"
                             ],
@@ -2391,42 +2480,43 @@
                     "name": "GradioLaunch",
                     "color": "blue",
                     "portsInOrder": [
-                        "9d6a86b4-93fd-4efc-9598-a6c7c7d6adc7",
-                        "36c49ac2-a5e7-4175-adc6-cf9a63c41ebb"
+                        "61e2966b-e05f-4d76-a2b0-cd595d2d8074",
+                        "e421943f-21f9-4edc-8c1a-b41733314d7f"
                     ],
                     "portsOutOrder": [
-                        "aa6f6d0c-fcaf-4c2b-8b71-987bdffd12a1"
+                        "d0e34393-06d9-4e68-8eda-4c6f795fed8f"
                     ]
                 },
-                "2457e4b2-e281-42ab-b24e-232567c31e66": {
-                    "id": "2457e4b2-e281-42ab-b24e-232567c31e66",
+                "937d0ee8-0b35-4305-ae78-e5699ed2170b": {
+                    "id": "937d0ee8-0b35-4305-ae78-e5699ed2170b",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
-                        "type": "library_component",
+                        "type": "branch",
                         "path": "xai_components/xai_gradio/gradio_component.py",
-                        "description": "Creates a Chatbot interface with support for text and image uploads.",
+                        "description": "Creates a Gradio Chatbot interface.\n\n##### outPorts:\n- interface (gr.Blocks): Gradio Blocks object for the chatbot interface. Connect to `GradioLaunch`.\n- message (str): the most recent user message.\n- history (list): Chat history for the session in OpenAi conversation format.\n\n##### Branches:\n- fn (BaseComponent): Subgraph executor for processing messages.",
                         "lineNo": [
                             {
-                                "lineno": 10,
-                                "end_lineno": 49
+                                "lineno": 7,
+                                "end_lineno": 93
                             }
                         ],
-                        "finishNodeId": "3cc38dc4-6215-4bfb-becf-9c1cbefc4eb5",
-                        "isBranchNode": true
+                        "finishNodeId": "86117b35-2c6d-4e17-a963-3778daf93a53",
+                        "isBranchNode": true,
+                        "borderColor": "rgb(0,192,255)"
                     },
                     "x": 1306.9036319656755,
                     "y": 20.801458195817084,
                     "ports": [
                         {
-                            "id": "1fc00600-c86d-4261-9c30-8c92debc28b9",
+                            "id": "488ffc1a-d517-47e2-8712-9c54ad9a9c98",
                             "type": "default",
                             "extras": {},
-                            "x": 1307.7000000609778,
-                            "y": 47.59996627629965,
+                            "x": 1307.5626437928493,
+                            "y": 47.45837238826978,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "2457e4b2-e281-42ab-b24e-232567c31e66",
+                            "parentNode": "937d0ee8-0b35-4305-ae78-e5699ed2170b",
                             "links": [
                                 "18df1d85-cdb1-4140-a26a-abcc297d1fd9"
                             ],
@@ -2437,14 +2527,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "9d5cd5aa-6bca-4eac-b449-24411789c1cc",
+                            "id": "2c30b823-e614-41fa-8c57-6d7d785d2961",
                             "type": "default",
                             "extras": {},
-                            "x": 1462.7751062400528,
-                            "y": 47.59996627629965,
+                            "x": 1462.8855423340608,
+                            "y": 47.45837238826978,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "2457e4b2-e281-42ab-b24e-232567c31e66",
+                            "parentNode": "937d0ee8-0b35-4305-ae78-e5699ed2170b",
                             "links": [
                                 "dd6192f3-1f15-426b-9ecd-e030767446b1"
                             ],
@@ -2455,14 +2545,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "eb1b135c-c0b0-4348-a239-b9c5d79d648a",
+                            "id": "7b2e47af-f979-432f-8ae3-fd343b6b52ae",
                             "type": "default",
                             "extras": {},
-                            "x": 1462.7751062400528,
-                            "y": 69.19997634410095,
+                            "x": 1462.8855423340608,
+                            "y": 68.79172408514937,
                             "name": "parameter-out-gr.Blocks-interface",
                             "alignment": "right",
-                            "parentNode": "2457e4b2-e281-42ab-b24e-232567c31e66",
+                            "parentNode": "937d0ee8-0b35-4305-ae78-e5699ed2170b",
                             "links": [
                                 "66bb0c96-c605-418b-94bc-df1adba9c3fb"
                             ],
@@ -2473,16 +2563,16 @@
                             "dataType": "gr.Blocks"
                         },
                         {
-                            "id": "cc12fb45-1d9c-40d8-b46d-f41dd2c15b64",
+                            "id": "93393714-5454-430e-aef9-3eed1a690345",
                             "type": "default",
                             "extras": {},
-                            "x": 1462.7751062400528,
-                            "y": 90.79998641190225,
+                            "x": 1462.8855423340608,
+                            "y": 90.12503182673207,
                             "name": "out-flow-fn",
                             "alignment": "right",
-                            "parentNode": "2457e4b2-e281-42ab-b24e-232567c31e66",
+                            "parentNode": "937d0ee8-0b35-4305-ae78-e5699ed2170b",
                             "links": [
-                                "98aec024-4f48-4b5f-a944-258ee828b3e6"
+                                "6f499d27-3271-4976-a976-65d747484f2b"
                             ],
                             "in": false,
                             "label": "fn ▶",
@@ -2491,16 +2581,17 @@
                             "dataType": ""
                         },
                         {
-                            "id": "93362715-68a8-416e-8c15-1300d6418d28",
+                            "id": "11eda4e8-a9c5-40ec-9fca-fde23a628c51",
                             "type": "default",
                             "extras": {},
-                            "x": 1462.7751062400528,
-                            "y": 112.39999647970356,
+                            "x": 1462.8855423340608,
+                            "y": 111.45833956831478,
                             "name": "parameter-out-string-message",
                             "alignment": "right",
-                            "parentNode": "2457e4b2-e281-42ab-b24e-232567c31e66",
+                            "parentNode": "937d0ee8-0b35-4305-ae78-e5699ed2170b",
                             "links": [
-                                "e43400e8-df06-4b04-9c2d-505ab9b615c1"
+                                "e43400e8-df06-4b04-9c2d-505ab9b615c1",
+                                "32449492-6723-426b-9bc3-1d01a04cc893"
                             ],
                             "in": false,
                             "label": "message",
@@ -2509,93 +2600,40 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "9bfea24c-7ac7-4823-b213-9ddda3036802",
+                            "id": "00e420dc-04ed-4560-a48f-2625998d1728",
                             "type": "default",
                             "extras": {},
-                            "x": 1462.7751062400528,
-                            "y": 134.00000654750485,
+                            "x": 1462.8855423340608,
+                            "y": 132.79169126519437,
                             "name": "parameter-out-list-history",
                             "alignment": "right",
-                            "parentNode": "2457e4b2-e281-42ab-b24e-232567c31e66",
+                            "parentNode": "937d0ee8-0b35-4305-ae78-e5699ed2170b",
                             "links": [
-                                "fefa6ade-23a9-4735-91a6-29720dad897e"
+                                "935964df-7e09-4c1e-ad42-f95f83c5a53a",
+                                "3a0a7cc2-092f-4405-b328-8cb47d38e3d1"
                             ],
                             "in": false,
                             "label": "history",
                             "varName": "history",
                             "portType": "",
                             "dataType": "list"
-                        },
-                        {
-                            "id": "e4c290d8-ae2d-4d3e-b3bc-ae5b1cf9c373",
-                            "type": "default",
-                            "extras": {},
-                            "x": 1462.7751062400528,
-                            "y": 155.60001661530617,
-                            "name": "parameter-out-any-uploaded_image",
-                            "alignment": "right",
-                            "parentNode": "2457e4b2-e281-42ab-b24e-232567c31e66",
-                            "links": [],
-                            "in": false,
-                            "label": "uploaded_image",
-                            "varName": "uploaded_image",
-                            "portType": "",
-                            "dataType": "any"
                         }
                     ],
                     "name": "GradioChatInterface",
                     "color": "blue",
                     "portsInOrder": [
-                        "1fc00600-c86d-4261-9c30-8c92debc28b9"
+                        "488ffc1a-d517-47e2-8712-9c54ad9a9c98"
                     ],
                     "portsOutOrder": [
-                        "9d5cd5aa-6bca-4eac-b449-24411789c1cc",
-                        "eb1b135c-c0b0-4348-a239-b9c5d79d648a",
-                        "cc12fb45-1d9c-40d8-b46d-f41dd2c15b64",
-                        "93362715-68a8-416e-8c15-1300d6418d28",
-                        "9bfea24c-7ac7-4823-b213-9ddda3036802",
-                        "e4c290d8-ae2d-4d3e-b3bc-ae5b1cf9c373"
+                        "2c30b823-e614-41fa-8c57-6d7d785d2961",
+                        "7b2e47af-f979-432f-8ae3-fd343b6b52ae",
+                        "93393714-5454-430e-aef9-3eed1a690345",
+                        "11eda4e8-a9c5-40ec-9fca-fde23a628c51",
+                        "00e420dc-04ed-4560-a48f-2625998d1728"
                     ]
                 },
-                "9b675880-18d2-4ded-9e41-d83d578603d5": {
-                    "id": "9b675880-18d2-4ded-9e41-d83d578603d5",
-                    "type": "custom-node",
-                    "selected": false,
-                    "extras": {
-                        "type": "boolean",
-                        "attached": true
-                    },
-                    "x": 2341.6947514765066,
-                    "y": 465.97843360514764,
-                    "ports": [
-                        {
-                            "id": "afe39e52-608b-47e3-b42c-215caae7777c",
-                            "type": "default",
-                            "extras": {},
-                            "x": 2341.694751476508,
-                            "y": 465.9784336051474,
-                            "name": "out-0",
-                            "alignment": "right",
-                            "parentNode": "9b675880-18d2-4ded-9e41-d83d578603d5",
-                            "links": [
-                                "7dd0ca4e-a249-486a-a5b3-af9410efa66e"
-                            ],
-                            "in": false,
-                            "label": "True",
-                            "varName": "True",
-                            "portType": "",
-                            "dataType": "boolean"
-                        }
-                    ],
-                    "name": "Literal Boolean",
-                    "color": "red",
-                    "portsInOrder": [],
-                    "portsOutOrder": [
-                        "afe39e52-608b-47e3-b42c-215caae7777c"
-                    ]
-                },
-                "dfcdef3c-3bb4-47ec-8137-266ed4aeddf2": {
-                    "id": "dfcdef3c-3bb4-47ec-8137-266ed4aeddf2",
+                "d4f2147f-cea6-4ffc-b71b-e89eefa50bb4": {
+                    "id": "d4f2147f-cea6-4ffc-b71b-e89eefa50bb4",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -2606,14 +2644,14 @@
                     "y": 235.07663809255408,
                     "ports": [
                         {
-                            "id": "0d76c278-5978-4859-9bb9-35890f6ea512",
+                            "id": "64a48f91-db5b-4999-98d2-0e01dd43e600",
                             "type": "default",
                             "extras": {},
-                            "x": 413.725041049226,
-                            "y": 258.8750293392941,
+                            "x": 337.90258573418964,
+                            "y": 235.07663809255408,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "dfcdef3c-3bb4-47ec-8137-266ed4aeddf2",
+                            "parentNode": "d4f2147f-cea6-4ffc-b71b-e89eefa50bb4",
                             "links": [
                                 "961320c7-b2bd-4170-8caf-ce9c7eae2fff"
                             ],
@@ -2628,11 +2666,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "0d76c278-5978-4859-9bb9-35890f6ea512"
+                        "64a48f91-db5b-4999-98d2-0e01dd43e600"
                     ]
                 },
-                "d8b5b14e-bcd5-4401-a725-d936918c7e15": {
-                    "id": "d8b5b14e-bcd5-4401-a725-d936918c7e15",
+                "44b30e7b-899a-45a3-9832-f72261078b70": {
+                    "id": "44b30e7b-899a-45a3-9832-f72261078b70",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -2645,22 +2683,22 @@
                                 "end_lineno": 61
                             }
                         ],
-                        "sourceBranchId": "d74c0df1-cd26-475e-82bd-7e8395b621c4",
-                        "portId": "3835a3ad-2aea-4004-a9ad-b2b910453683",
+                        "sourceBranchId": "8ba4e1d5-f9d7-4b6f-8e4f-b5fee61041f5",
+                        "portId": "b58fee7a-4169-4ebf-bb2f-333acec661b0",
                         "nextNode": "None"
                     },
-                    "x": 2763.9583126283646,
-                    "y": 225.66173707718872,
+                    "x": 2664.8790293193106,
+                    "y": 199.07949033573522,
                     "ports": [
                         {
-                            "id": "ec12b5a5-b6c4-4c0c-9c07-160f78a94e11",
+                            "id": "9176b869-4c5b-4784-aa68-b5b6f8b99c85",
                             "type": "default",
                             "extras": {},
-                            "x": 2764.7501876691163,
-                            "y": 252.45005328269613,
+                            "x": 2665.5418488349324,
+                            "y": 225.73964995190386,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "d8b5b14e-bcd5-4401-a725-d936918c7e15",
+                            "parentNode": "44b30e7b-899a-45a3-9832-f72261078b70",
                             "links": [
                                 "58aacc28-7bbd-48f8-b6fc-de12168e2931"
                             ],
@@ -2671,14 +2709,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "0b8c60ee-65ce-48ea-a3cc-5353aad05b1e",
+                            "id": "13debabd-3930-4c62-b0be-560743eecd33",
                             "type": "default",
                             "extras": {},
-                            "x": 2764.7501876691163,
-                            "y": 274.0499108080535,
+                            "x": 2665.5418488349324,
+                            "y": 247.07300164878345,
                             "name": "parameter-any-msg",
                             "alignment": "left",
-                            "parentNode": "d8b5b14e-bcd5-4401-a725-d936918c7e15",
+                            "parentNode": "44b30e7b-899a-45a3-9832-f72261078b70",
                             "links": [
                                 "ef8a4b31-636b-4b25-982a-84d7e2b7ddb7"
                             ],
@@ -2689,14 +2727,14 @@
                             "dataType": "any"
                         },
                         {
-                            "id": "3d8a27ee-b7b0-4761-85fe-fe6a0bd008ea",
+                            "id": "5f49221c-1d45-4b68-b1ff-099ba8de1faa",
                             "type": "default",
                             "extras": {},
-                            "x": 2837.7875098475292,
-                            "y": 252.45005328269613,
+                            "x": 2738.843811761277,
+                            "y": 225.73964995190386,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "d8b5b14e-bcd5-4401-a725-d936918c7e15",
+                            "parentNode": "44b30e7b-899a-45a3-9832-f72261078b70",
                             "links": [],
                             "in": false,
                             "label": "▶",
@@ -2708,15 +2746,15 @@
                     "name": "Print",
                     "color": "rgb(255,153,0)",
                     "portsInOrder": [
-                        "ec12b5a5-b6c4-4c0c-9c07-160f78a94e11",
-                        "0b8c60ee-65ce-48ea-a3cc-5353aad05b1e"
+                        "9176b869-4c5b-4784-aa68-b5b6f8b99c85",
+                        "13debabd-3930-4c62-b0be-560743eecd33"
                     ],
                     "portsOutOrder": [
-                        "3d8a27ee-b7b0-4761-85fe-fe6a0bd008ea"
+                        "5f49221c-1d45-4b68-b1ff-099ba8de1faa"
                     ]
                 },
-                "d74c0df1-cd26-475e-82bd-7e8395b621c4": {
-                    "id": "d74c0df1-cd26-475e-82bd-7e8395b621c4",
+                "8ba4e1d5-f9d7-4b6f-8e4f-b5fee61041f5": {
+                    "id": "8ba4e1d5-f9d7-4b6f-8e4f-b5fee61041f5",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -2726,26 +2764,27 @@
                         "lineNo": [
                             {
                                 "lineno": 361,
-                                "end_lineno": 598
+                                "end_lineno": 597
                             }
                         ],
-                        "finishNodeId": "41aff0fa-745d-48dc-a878-9617f76afd85",
-                        "isBranchNode": true
+                        "finishNodeId": "c304a0df-a115-4489-8114-73a0c87ae1d0",
+                        "isBranchNode": true,
+                        "borderColor": "rgb(0,192,255)"
                     },
-                    "x": 2343.9794396278926,
-                    "y": 6.499148389790008,
+                    "x": 2308.4788061481563,
+                    "y": -145.38916460893267,
                     "ports": [
                         {
-                            "id": "f936b8a0-0c06-4e0a-98a2-bee2f8227200",
+                            "id": "205c81ac-4f8a-4ae4-b48a-4154eced6dd2",
                             "type": "default",
                             "extras": {},
-                            "x": 2344.7752122570514,
-                            "y": 33.2873663848336,
+                            "x": 2309.135422922171,
+                            "y": -118.71871529785894,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "d74c0df1-cd26-475e-82bd-7e8395b621c4",
+                            "parentNode": "8ba4e1d5-f9d7-4b6f-8e4f-b5fee61041f5",
                             "links": [
-                                "316026a3-be2a-496a-9abc-12c8bc638fff"
+                                "121f7185-a5b9-4cbe-941f-1b9ceb0890b2"
                             ],
                             "in": true,
                             "label": "▶",
@@ -2754,14 +2793,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "2b3b8e5e-3dd3-4d86-8429-c984f30184d7",
+                            "id": "edcec856-a1b5-4db1-b226-303654c16d8c",
                             "type": "default",
                             "extras": {},
-                            "x": 2344.7752122570514,
-                            "y": 54.8873764526349,
+                            "x": 2309.135422922171,
+                            "y": -97.38540755627623,
                             "name": "parameter-string-agent_name",
                             "alignment": "left",
-                            "parentNode": "d74c0df1-cd26-475e-82bd-7e8395b621c4",
+                            "parentNode": "8ba4e1d5-f9d7-4b6f-8e4f-b5fee61041f5",
                             "links": [
                                 "44806538-bd83-41d4-9d83-4a7ac59af827"
                             ],
@@ -2772,16 +2811,16 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "efbde000-a539-43b1-b74f-207f901530b1",
+                            "id": "8c9bd8c4-877d-49d0-a51b-a0cd7731918c",
                             "type": "default",
                             "extras": {},
-                            "x": 2344.7752122570514,
-                            "y": 74.88752136795668,
+                            "x": 2309.135422922171,
+                            "y": -77.38539583486373,
                             "name": "parameter-any-conversation",
                             "alignment": "left",
-                            "parentNode": "d74c0df1-cd26-475e-82bd-7e8395b621c4",
+                            "parentNode": "8ba4e1d5-f9d7-4b6f-8e4f-b5fee61041f5",
                             "links": [
-                                "acb29746-1b90-46fe-9c52-ab9d5a503d4d"
+                                "0f56f52f-84dd-4ea7-9983-bbb78c2e3b75"
                             ],
                             "in": true,
                             "label": "★conversation",
@@ -2790,16 +2829,16 @@
                             "dataType": "any"
                         },
                         {
-                            "id": "191f4f0b-62b2-4b7c-82de-2a02d51f70ae",
+                            "id": "63d02692-589e-4f3c-bd28-4e374b15540c",
                             "type": "default",
                             "extras": {},
-                            "x": 2590.7248862166452,
-                            "y": 33.2873663848336,
+                            "x": 2555.447895853034,
+                            "y": -118.71871529785894,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "d74c0df1-cd26-475e-82bd-7e8395b621c4",
+                            "parentNode": "8ba4e1d5-f9d7-4b6f-8e4f-b5fee61041f5",
                             "links": [
-                                "dbc1d445-31ea-43aa-b9a7-d188e65b9c37"
+                                "c9471436-1c46-401d-b93e-0a73b7d2f7b5"
                             ],
                             "in": false,
                             "label": "▶",
@@ -2808,14 +2847,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "3835a3ad-2aea-4004-a9ad-b2b910453683",
+                            "id": "b58fee7a-4169-4ebf-bb2f-333acec661b0",
                             "type": "default",
                             "extras": {},
-                            "x": 2590.7248862166452,
-                            "y": 54.8873764526349,
+                            "x": 2555.447895853034,
+                            "y": -97.38540755627623,
                             "name": "out-flow-on_thought",
                             "alignment": "right",
-                            "parentNode": "d74c0df1-cd26-475e-82bd-7e8395b621c4",
+                            "parentNode": "8ba4e1d5-f9d7-4b6f-8e4f-b5fee61041f5",
                             "links": [
                                 "58aacc28-7bbd-48f8-b6fc-de12168e2931"
                             ],
@@ -2826,14 +2865,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "425b8a2c-ba2d-47b4-891d-4fbbb9b48dba",
+                            "id": "f15b0643-f258-4cb1-be32-faa28ec1baf7",
                             "type": "default",
                             "extras": {},
-                            "x": 2590.7248862166452,
-                            "y": 76.4873865204362,
+                            "x": 2555.447895853034,
+                            "y": -76.05205585939665,
                             "name": "parameter-out-list-out_conversation",
                             "alignment": "right",
-                            "parentNode": "d74c0df1-cd26-475e-82bd-7e8395b621c4",
+                            "parentNode": "8ba4e1d5-f9d7-4b6f-8e4f-b5fee61041f5",
                             "links": [],
                             "in": false,
                             "label": "out_conversation",
@@ -2842,17 +2881,18 @@
                             "dataType": "list"
                         },
                         {
-                            "id": "e67a89b1-9d9b-4ab4-afcb-8daf300437f7",
+                            "id": "69f117ea-215b-4b61-9dcf-188ad94e60ed",
                             "type": "default",
                             "extras": {},
-                            "x": 2590.7248862166452,
-                            "y": 98.08739658823751,
+                            "x": 2555.447895853034,
+                            "y": -54.71870416251706,
                             "name": "parameter-out-string-last_response",
                             "alignment": "right",
-                            "parentNode": "d74c0df1-cd26-475e-82bd-7e8395b621c4",
+                            "parentNode": "8ba4e1d5-f9d7-4b6f-8e4f-b5fee61041f5",
                             "links": [
-                                "67edcd84-0152-4c7e-a93b-7da7b95ab778",
-                                "ef8a4b31-636b-4b25-982a-84d7e2b7ddb7"
+                                "ef8a4b31-636b-4b25-982a-84d7e2b7ddb7",
+                                "62e4919b-12d7-4823-8dfe-fabfb204013f",
+                                "29577b31-ec84-45d3-8f14-12f54adf514b"
                             ],
                             "in": false,
                             "label": "last_response",
@@ -2862,21 +2902,21 @@
                         }
                     ],
                     "name": "AgentRun",
-                    "color": "rgb(192,255,0)",
+                    "color": "rgb(15,255,255)",
                     "portsInOrder": [
-                        "f936b8a0-0c06-4e0a-98a2-bee2f8227200",
-                        "2b3b8e5e-3dd3-4d86-8429-c984f30184d7",
-                        "efbde000-a539-43b1-b74f-207f901530b1"
+                        "205c81ac-4f8a-4ae4-b48a-4154eced6dd2",
+                        "edcec856-a1b5-4db1-b226-303654c16d8c",
+                        "8c9bd8c4-877d-49d0-a51b-a0cd7731918c"
                     ],
                     "portsOutOrder": [
-                        "191f4f0b-62b2-4b7c-82de-2a02d51f70ae",
-                        "3835a3ad-2aea-4004-a9ad-b2b910453683",
-                        "425b8a2c-ba2d-47b4-891d-4fbbb9b48dba",
-                        "e67a89b1-9d9b-4ab4-afcb-8daf300437f7"
+                        "63d02692-589e-4f3c-bd28-4e374b15540c",
+                        "b58fee7a-4169-4ebf-bb2f-333acec661b0",
+                        "f15b0643-f258-4cb1-be32-faa28ec1baf7",
+                        "69f117ea-215b-4b61-9dcf-188ad94e60ed"
                     ]
                 },
-                "ffbedfd5-a889-463c-8c8e-a674934cfdcc": {
-                    "id": "ffbedfd5-a889-463c-8c8e-a674934cfdcc",
+                "918d8b81-a46f-4962-800a-1edf2cb6f648": {
+                    "id": "918d8b81-a46f-4962-800a-1edf2cb6f648",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -2888,22 +2928,23 @@
                                 "lineno": 508,
                                 "end_lineno": 525
                             }
-                        ]
+                        ],
+                        "borderColor": "rgb(0,192,255)"
                     },
-                    "x": 2114.6734582180607,
-                    "y": 11.865744501794836,
+                    "x": 2136.0523502355727,
+                    "y": -173.0727550849609,
                     "ports": [
                         {
-                            "id": "0d372d87-ff9f-415a-97af-f3b8bdf5704a",
+                            "id": "7e3daaa1-6916-468d-b31c-384a3d9c0906",
                             "type": "default",
                             "extras": {},
-                            "x": 2115.462427407872,
-                            "y": 38.662504483414914,
+                            "x": 2136.7188368890547,
+                            "y": -146.3957833506217,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "ffbedfd5-a889-463c-8c8e-a674934cfdcc",
+                            "parentNode": "918d8b81-a46f-4962-800a-1edf2cb6f648",
                             "links": [
-                                "a45a75e5-8707-41fe-a7f2-266b7dc80155"
+                                "849545b6-7d2f-4c6a-9a3d-7c9ad30b3ca1"
                             ],
                             "in": true,
                             "label": "▶",
@@ -2912,16 +2953,16 @@
                             "dataType": ""
                         },
                         {
-                            "id": "b0157cf3-c761-4fe4-b32d-43dd28e4baa9",
+                            "id": "7c0745da-6e0b-4f6d-a092-7005ef9c9261",
                             "type": "default",
                             "extras": {},
-                            "x": 2115.462427407872,
-                            "y": 60.26251455121622,
+                            "x": 2136.7188368890547,
+                            "y": -125.062475609039,
                             "name": "parameter-list-the_list",
                             "alignment": "left",
-                            "parentNode": "ffbedfd5-a889-463c-8c8e-a674934cfdcc",
+                            "parentNode": "918d8b81-a46f-4962-800a-1edf2cb6f648",
                             "links": [
-                                "fefa6ade-23a9-4735-91a6-29720dad897e"
+                                "8b220192-2108-412f-87e3-0bb6c02bed1d"
                             ],
                             "in": true,
                             "label": "the_list",
@@ -2930,14 +2971,14 @@
                             "dataType": "list"
                         },
                         {
-                            "id": "bb1e0d75-eafc-411e-987a-98741ab9807c",
+                            "id": "1c58e91e-3abb-4f95-924e-c60a577ebd5b",
                             "type": "default",
                             "extras": {},
-                            "x": 2115.462427407872,
-                            "y": 81.86237207657354,
+                            "x": 2136.7188368890547,
+                            "y": -103.72912391215941,
                             "name": "parameter-any-item",
                             "alignment": "left",
-                            "parentNode": "ffbedfd5-a889-463c-8c8e-a674934cfdcc",
+                            "parentNode": "918d8b81-a46f-4962-800a-1edf2cb6f648",
                             "links": [
                                 "434ec92d-5fff-4711-9d58-1d717360dc3d"
                             ],
@@ -2948,16 +2989,16 @@
                             "dataType": "any"
                         },
                         {
-                            "id": "662cf5ac-fd42-4a47-acb3-c8b45732352f",
+                            "id": "556f6d87-bebb-429b-aefb-7e17b2544394",
                             "type": "default",
                             "extras": {},
-                            "x": 2235.787602135708,
-                            "y": 38.662504483414914,
+                            "x": 2256.7604010177815,
+                            "y": -146.3957833506217,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "ffbedfd5-a889-463c-8c8e-a674934cfdcc",
+                            "parentNode": "918d8b81-a46f-4962-800a-1edf2cb6f648",
                             "links": [
-                                "316026a3-be2a-496a-9abc-12c8bc638fff"
+                                "121f7185-a5b9-4cbe-941f-1b9ceb0890b2"
                             ],
                             "in": false,
                             "label": "▶",
@@ -2966,16 +3007,16 @@
                             "dataType": ""
                         },
                         {
-                            "id": "13f4c15b-3929-4f65-96de-633468fceb34",
+                            "id": "b4abb070-1777-463a-a2e7-7268b2e76502",
                             "type": "default",
                             "extras": {},
-                            "x": 2235.787602135708,
-                            "y": 60.26251455121622,
+                            "x": 2256.7604010177815,
+                            "y": -125.062475609039,
                             "name": "parameter-out-list-out_list",
                             "alignment": "right",
-                            "parentNode": "ffbedfd5-a889-463c-8c8e-a674934cfdcc",
+                            "parentNode": "918d8b81-a46f-4962-800a-1edf2cb6f648",
                             "links": [
-                                "acb29746-1b90-46fe-9c52-ab9d5a503d4d"
+                                "0f56f52f-84dd-4ea7-9983-bbb78c2e3b75"
                             ],
                             "in": false,
                             "label": "out_list",
@@ -2987,17 +3028,17 @@
                     "name": "ListAppend",
                     "color": "rgb(153,204,204)",
                     "portsInOrder": [
-                        "0d372d87-ff9f-415a-97af-f3b8bdf5704a",
-                        "b0157cf3-c761-4fe4-b32d-43dd28e4baa9",
-                        "bb1e0d75-eafc-411e-987a-98741ab9807c"
+                        "7e3daaa1-6916-468d-b31c-384a3d9c0906",
+                        "7c0745da-6e0b-4f6d-a092-7005ef9c9261",
+                        "1c58e91e-3abb-4f95-924e-c60a577ebd5b"
                     ],
                     "portsOutOrder": [
-                        "662cf5ac-fd42-4a47-acb3-c8b45732352f",
-                        "13f4c15b-3929-4f65-96de-633468fceb34"
+                        "556f6d87-bebb-429b-aefb-7e17b2544394",
+                        "b4abb070-1777-463a-a2e7-7268b2e76502"
                     ]
                 },
-                "58650b5f-5eaf-4d12-8e81-e27dfbf82f28": {
-                    "id": "58650b5f-5eaf-4d12-8e81-e27dfbf82f28",
+                "0cce3adb-b828-4056-9c10-1260dc5a5e99": {
+                    "id": "0cce3adb-b828-4056-9c10-1260dc5a5e99",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -3008,14 +3049,14 @@
                     "y": 270.46916465100304,
                     "ports": [
                         {
-                            "id": "54053683-805b-4e33-abaa-90aed9f9b7d0",
+                            "id": "86c891a6-bd6a-45b3-b821-26733521d47c",
                             "type": "default",
                             "extras": {},
-                            "x": 1482.6603089177675,
-                            "y": 270.4691646510029,
+                            "x": 1482.6603089177681,
+                            "y": 270.46916465100304,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "58650b5f-5eaf-4d12-8e81-e27dfbf82f28",
+                            "parentNode": "0cce3adb-b828-4056-9c10-1260dc5a5e99",
                             "links": [
                                 "3917abf5-443f-4b1f-809c-1d7dc6b3cc17"
                             ],
@@ -3030,11 +3071,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "54053683-805b-4e33-abaa-90aed9f9b7d0"
+                        "86c891a6-bd6a-45b3-b821-26733521d47c"
                     ]
                 },
-                "adf28ede-0322-42a7-8efe-d7da0162357c": {
-                    "id": "adf28ede-0322-42a7-8efe-d7da0162357c",
+                "f2502fd7-4c63-48e7-ad8f-9be24567a16e": {
+                    "id": "f2502fd7-4c63-48e7-ad8f-9be24567a16e",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -3045,14 +3086,14 @@
                     "y": 323.5045920286451,
                     "ports": [
                         {
-                            "id": "f17b2f06-7f3e-461a-a5fb-52ef28ca9200",
+                            "id": "a9c6e206-49c4-412e-b69f-51f57f26331c",
                             "type": "default",
                             "extras": {},
-                            "x": 1483.6802209827233,
-                            "y": 323.5045920286449,
+                            "x": 1483.6802209827229,
+                            "y": 323.5045920286451,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "adf28ede-0322-42a7-8efe-d7da0162357c",
+                            "parentNode": "f2502fd7-4c63-48e7-ad8f-9be24567a16e",
                             "links": [
                                 "97ba259a-33e9-4d99-b4c1-4fd4598099e9"
                             ],
@@ -3067,11 +3108,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "f17b2f06-7f3e-461a-a5fb-52ef28ca9200"
+                        "a9c6e206-49c4-412e-b69f-51f57f26331c"
                     ]
                 },
-                "5efe0234-cd2b-4c87-8f5e-47124aff058d": {
-                    "id": "5efe0234-cd2b-4c87-8f5e-47124aff058d",
+                "101f9ad0-d628-4017-aa74-17d1b4116d00": {
+                    "id": "101f9ad0-d628-4017-aa74-17d1b4116d00",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -3082,14 +3123,14 @@
                     "y": 376.54001940628706,
                     "ports": [
                         {
-                            "id": "32e5677f-f725-4a3e-b8ab-5f0ff90c908e",
+                            "id": "1bb7e886-4767-49fc-846a-2a5499bbd2c6",
                             "type": "default",
                             "extras": {},
-                            "x": 1483.6802209827224,
-                            "y": 376.54001940628694,
+                            "x": 1483.680220982723,
+                            "y": 376.54001940628706,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "5efe0234-cd2b-4c87-8f5e-47124aff058d",
+                            "parentNode": "101f9ad0-d628-4017-aa74-17d1b4116d00",
                             "links": [
                                 "41df7e60-fab1-404d-93a3-91d55f1b0a69"
                             ],
@@ -3104,11 +3145,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "32e5677f-f725-4a3e-b8ab-5f0ff90c908e"
+                        "1bb7e886-4767-49fc-846a-2a5499bbd2c6"
                     ]
                 },
-                "1fe3ee5d-8dcb-44e4-836e-6ebe28f7487b": {
-                    "id": "1fe3ee5d-8dcb-44e4-836e-6ebe28f7487b",
+                "543b7dc4-3c07-4258-a01c-ce62c7d5e15c": {
+                    "id": "543b7dc4-3c07-4258-a01c-ce62c7d5e15c",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -3121,23 +3162,24 @@
                                 "end_lineno": 383
                             }
                         ],
-                        "sourceBranchId": "2457e4b2-e281-42ab-b24e-232567c31e66",
-                        "portId": "cc12fb45-1d9c-40d8-b46d-f41dd2c15b64"
+                        "sourceBranchId": "937d0ee8-0b35-4305-ae78-e5699ed2170b",
+                        "portId": "93393714-5454-430e-aef9-3eed1a690345",
+                        "borderColor": "rgb(0,192,255)"
                     },
-                    "x": 1697.4765843642874,
-                    "y": 6.194447125726612,
+                    "x": 1678.5365404910701,
+                    "y": -212.3717794014382,
                     "ports": [
                         {
-                            "id": "7210e51f-42b5-4186-a53e-2bdc6f477419",
+                            "id": "f4ca7d29-16e5-4236-9d48-f58743d9842b",
                             "type": "default",
                             "extras": {},
-                            "x": 1698.275012617128,
-                            "y": 32.987467939965676,
+                            "x": 1679.1983493251803,
+                            "y": -185.69788458963362,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "1fe3ee5d-8dcb-44e4-836e-6ebe28f7487b",
+                            "parentNode": "543b7dc4-3c07-4258-a01c-ce62c7d5e15c",
                             "links": [
-                                "98aec024-4f48-4b5f-a944-258ee828b3e6"
+                                "6f499d27-3271-4976-a976-65d747484f2b"
                             ],
                             "in": true,
                             "label": "▶",
@@ -3146,14 +3188,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "a6b67d22-12cd-4cf1-b168-1169e8473605",
+                            "id": "6cae758b-23dd-49e2-afa4-6b46376f83ee",
                             "type": "default",
                             "extras": {},
-                            "x": 1698.275012617128,
-                            "y": 54.58747800776698,
+                            "x": 1679.1983493251803,
+                            "y": -164.36457684805092,
                             "name": "parameter-dynalist-keys_list",
                             "alignment": "left",
-                            "parentNode": "1fe3ee5d-8dcb-44e4-836e-6ebe28f7487b",
+                            "parentNode": "543b7dc4-3c07-4258-a01c-ce62c7d5e15c",
                             "links": [
                                 "3917abf5-443f-4b1f-809c-1d7dc6b3cc17"
                             ],
@@ -3165,18 +3207,18 @@
                             "dynaPortOrder": 0,
                             "dynaPortRef": {
                                 "previous": null,
-                                "next": "cfd4e82d-eaf5-4607-a437-d3366e9f2e88"
+                                "next": "31359e66-2b10-4335-941d-357465db92ff"
                             }
                         },
                         {
-                            "id": "cfd4e82d-eaf5-4607-a437-d3366e9f2e88",
+                            "id": "31359e66-2b10-4335-941d-357465db92ff",
                             "type": "default",
                             "extras": {},
-                            "x": 1698.275012617128,
-                            "y": 74.58747038064479,
+                            "x": 1679.1983493251803,
+                            "y": -144.36452117134152,
                             "name": "parameter-dynalist-keys_list-1",
                             "alignment": "left",
-                            "parentNode": "1fe3ee5d-8dcb-44e4-836e-6ebe28f7487b",
+                            "parentNode": "543b7dc4-3c07-4258-a01c-ce62c7d5e15c",
                             "links": [
                                 "97ba259a-33e9-4d99-b4c1-4fd4598099e9"
                             ],
@@ -3187,19 +3229,19 @@
                             "dataType": "dynalist",
                             "dynaPortOrder": 1,
                             "dynaPortRef": {
-                                "previous": "a6b67d22-12cd-4cf1-b168-1169e8473605",
-                                "next": "8b7e5dc0-54db-47ac-abc3-71a2135792a9"
+                                "previous": "6cae758b-23dd-49e2-afa4-6b46376f83ee",
+                                "next": "a5471355-29d5-415b-b91f-da076ef8d07b"
                             }
                         },
                         {
-                            "id": "8b7e5dc0-54db-47ac-abc3-71a2135792a9",
+                            "id": "a5471355-29d5-415b-b91f-da076ef8d07b",
                             "type": "default",
                             "extras": {},
-                            "x": 1698.275012617128,
-                            "y": 94.58746275352259,
+                            "x": 1679.1983493251803,
+                            "y": -124.3645534052259,
                             "name": "parameter-dynalist-keys_list-2",
                             "alignment": "left",
-                            "parentNode": "1fe3ee5d-8dcb-44e4-836e-6ebe28f7487b",
+                            "parentNode": "543b7dc4-3c07-4258-a01c-ce62c7d5e15c",
                             "links": [],
                             "in": true,
                             "label": "keys_list[2]",
@@ -3208,19 +3250,19 @@
                             "dataType": "dynalist",
                             "dynaPortOrder": 2,
                             "dynaPortRef": {
-                                "previous": "cfd4e82d-eaf5-4607-a437-d3366e9f2e88",
+                                "previous": "31359e66-2b10-4335-941d-357465db92ff",
                                 "next": null
                             }
                         },
                         {
-                            "id": "f831c52c-5989-4e7d-aaa2-ad8639bcbe6b",
+                            "id": "f947c376-0e75-44fb-b4de-a3dd8387763e",
                             "type": "default",
                             "extras": {},
-                            "x": 1698.275012617128,
-                            "y": 116.18754909254588,
+                            "x": 1679.1983493251803,
+                            "y": -103.03120170834632,
                             "name": "parameter-dynalist-values_list",
                             "alignment": "left",
-                            "parentNode": "1fe3ee5d-8dcb-44e4-836e-6ebe28f7487b",
+                            "parentNode": "543b7dc4-3c07-4258-a01c-ce62c7d5e15c",
                             "links": [
                                 "41df7e60-fab1-404d-93a3-91d55f1b0a69"
                             ],
@@ -3232,18 +3274,18 @@
                             "dynaPortOrder": 0,
                             "dynaPortRef": {
                                 "previous": null,
-                                "next": "4a6c5ff5-c61e-443e-9360-677701e92bfd"
+                                "next": "f50dd76a-043b-42ee-b401-dfb44b6676a0"
                             }
                         },
                         {
-                            "id": "4a6c5ff5-c61e-443e-9360-677701e92bfd",
+                            "id": "f50dd76a-043b-42ee-b401-dfb44b6676a0",
                             "type": "default",
                             "extras": {},
-                            "x": 1698.275012617128,
-                            "y": 136.18746519420168,
+                            "x": 1679.1983493251803,
+                            "y": -83.0312339422307,
                             "name": "parameter-dynalist-values_list-1",
                             "alignment": "left",
-                            "parentNode": "1fe3ee5d-8dcb-44e4-836e-6ebe28f7487b",
+                            "parentNode": "543b7dc4-3c07-4258-a01c-ce62c7d5e15c",
                             "links": [
                                 "e43400e8-df06-4b04-9c2d-505ab9b615c1"
                             ],
@@ -3254,19 +3296,19 @@
                             "dataType": "dynalist",
                             "dynaPortOrder": 1,
                             "dynaPortRef": {
-                                "previous": "f831c52c-5989-4e7d-aaa2-ad8639bcbe6b",
-                                "next": "8594483d-531a-45d2-b38a-ed4a58583510"
+                                "previous": "f947c376-0e75-44fb-b4de-a3dd8387763e",
+                                "next": "13fe01f5-7acd-4e28-a690-60677771675a"
                             }
                         },
                         {
-                            "id": "8594483d-531a-45d2-b38a-ed4a58583510",
+                            "id": "13fe01f5-7acd-4e28-a690-60677771675a",
                             "type": "default",
                             "extras": {},
-                            "x": 1698.275012617128,
-                            "y": 157.787475262003,
+                            "x": 1679.1983493251803,
+                            "y": -61.69783829005423,
                             "name": "parameter-dynalist-values_list-2",
                             "alignment": "left",
-                            "parentNode": "1fe3ee5d-8dcb-44e4-836e-6ebe28f7487b",
+                            "parentNode": "543b7dc4-3c07-4258-a01c-ce62c7d5e15c",
                             "links": [],
                             "in": true,
                             "label": "values_list[2]",
@@ -3275,21 +3317,21 @@
                             "dataType": "dynalist",
                             "dynaPortOrder": 2,
                             "dynaPortRef": {
-                                "previous": "4a6c5ff5-c61e-443e-9360-677701e92bfd",
+                                "previous": "f50dd76a-043b-42ee-b401-dfb44b6676a0",
                                 "next": null
                             }
                         },
                         {
-                            "id": "04e04ab3-f377-4f0b-882b-0a67d6386d4e",
+                            "id": "7eee2cae-f738-448a-96e9-1410907a8673",
                             "type": "default",
                             "extras": {},
-                            "x": 1898.7127331601332,
-                            "y": 32.987467939965676,
+                            "x": 1879.6355580114503,
+                            "y": -185.69788458963362,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "1fe3ee5d-8dcb-44e4-836e-6ebe28f7487b",
+                            "parentNode": "543b7dc4-3c07-4258-a01c-ce62c7d5e15c",
                             "links": [
-                                "a45a75e5-8707-41fe-a7f2-266b7dc80155"
+                                "2c81389b-d70a-487f-93f6-a46829c5cc47"
                             ],
                             "in": false,
                             "label": "▶",
@@ -3298,14 +3340,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "9d183da3-7815-4f68-95ec-d4f2da20b941",
+                            "id": "07e6cea9-e1fe-4937-bb69-321ae58dcfb6",
                             "type": "default",
                             "extras": {},
-                            "x": 1898.7127331601332,
-                            "y": 54.58747800776698,
+                            "x": 1879.6355580114503,
+                            "y": -164.36457684805092,
                             "name": "parameter-out-dict-output_dict",
                             "alignment": "right",
-                            "parentNode": "1fe3ee5d-8dcb-44e4-836e-6ebe28f7487b",
+                            "parentNode": "543b7dc4-3c07-4258-a01c-ce62c7d5e15c",
                             "links": [
                                 "434ec92d-5fff-4711-9d58-1d717360dc3d"
                             ],
@@ -3319,234 +3361,21 @@
                     "name": "MakeDict",
                     "color": "grey",
                     "portsInOrder": [
-                        "7210e51f-42b5-4186-a53e-2bdc6f477419",
-                        "a6b67d22-12cd-4cf1-b168-1169e8473605",
-                        "cfd4e82d-eaf5-4607-a437-d3366e9f2e88",
-                        "8b7e5dc0-54db-47ac-abc3-71a2135792a9",
-                        "f831c52c-5989-4e7d-aaa2-ad8639bcbe6b",
-                        "4a6c5ff5-c61e-443e-9360-677701e92bfd",
-                        "8594483d-531a-45d2-b38a-ed4a58583510"
+                        "f4ca7d29-16e5-4236-9d48-f58743d9842b",
+                        "6cae758b-23dd-49e2-afa4-6b46376f83ee",
+                        "31359e66-2b10-4335-941d-357465db92ff",
+                        "a5471355-29d5-415b-b91f-da076ef8d07b",
+                        "f947c376-0e75-44fb-b4de-a3dd8387763e",
+                        "f50dd76a-043b-42ee-b401-dfb44b6676a0",
+                        "13fe01f5-7acd-4e28-a690-60677771675a"
                     ],
                     "portsOutOrder": [
-                        "04e04ab3-f377-4f0b-882b-0a67d6386d4e",
-                        "9d183da3-7815-4f68-95ec-d4f2da20b941"
+                        "7eee2cae-f738-448a-96e9-1410907a8673",
+                        "07e6cea9-e1fe-4937-bb69-321ae58dcfb6"
                     ]
                 },
-                "41aff0fa-745d-48dc-a878-9617f76afd85": {
-                    "id": "41aff0fa-745d-48dc-a878-9617f76afd85",
-                    "type": "custom-node",
-                    "selected": false,
-                    "extras": {
-                        "type": "library_component",
-                        "path": "xai_components/xai_gradio/gradio_component.py",
-                        "description": "Collects return values for a Gradio function, integrates predefined responses from ctx,\nOpenAI, Agent, and appends chat history with timestamps.\n\n##### inPorts:\n- results (list[any]): Results for the Gradio function.\n- message (str): The user message to process.\n- history (list): Chat history to update and save (optional).\n- use_responses (bool): Whether to use predefined responses from ctx.\n- use_openai (bool): Whether to use OpenAI for generating responses.\n- use_agent (bool): Whether to use Agent for generating responses.\n- log_file (str): Path to the file where the conversation history will be saved (optional).",
-                        "lineNo": [
-                            {
-                                "lineno": 113,
-                                "end_lineno": 224
-                            }
-                        ],
-                        "nextNode": "None"
-                    },
-                    "x": 2747.249091889553,
-                    "y": -94.64681591625413,
-                    "ports": [
-                        {
-                            "id": "18bb550d-b233-4097-8a5e-087be6325ca2",
-                            "type": "default",
-                            "extras": {},
-                            "x": 2748.037637506487,
-                            "y": -67.83744346147608,
-                            "name": "in-0",
-                            "alignment": "left",
-                            "parentNode": "41aff0fa-745d-48dc-a878-9617f76afd85",
-                            "links": [
-                                "dbc1d445-31ea-43aa-b9a7-d188e65b9c37"
-                            ],
-                            "in": true,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        },
-                        {
-                            "id": "82ff7589-4960-4f01-8c76-09ab1762eb84",
-                            "type": "default",
-                            "extras": {},
-                            "x": 2748.037637506487,
-                            "y": -46.23743339367478,
-                            "name": "parameter-dynalist-results",
-                            "alignment": "left",
-                            "parentNode": "41aff0fa-745d-48dc-a878-9617f76afd85",
-                            "links": [
-                                "67edcd84-0152-4c7e-a93b-7da7b95ab778"
-                            ],
-                            "in": true,
-                            "label": "results",
-                            "varName": "results",
-                            "portType": "",
-                            "dataType": "dynalist",
-                            "dynaPortOrder": 0,
-                            "dynaPortRef": {
-                                "previous": null,
-                                "next": "1dc4deee-abf4-4cdc-b5fa-f3836d02d5d6"
-                            }
-                        },
-                        {
-                            "id": "1dc4deee-abf4-4cdc-b5fa-f3836d02d5d6",
-                            "type": "default",
-                            "extras": {},
-                            "x": 2748.037637506487,
-                            "y": -24.637575868317455,
-                            "name": "parameter-dynalist-results-1",
-                            "alignment": "left",
-                            "parentNode": "41aff0fa-745d-48dc-a878-9617f76afd85",
-                            "links": [],
-                            "in": true,
-                            "label": "results[1]",
-                            "varName": "results",
-                            "portType": "",
-                            "dataType": "dynalist",
-                            "dynaPortOrder": 1,
-                            "dynaPortRef": {
-                                "previous": "82ff7589-4960-4f01-8c76-09ab1762eb84",
-                                "next": null
-                            }
-                        },
-                        {
-                            "id": "34a6a1b5-6d97-4884-beb3-b42003a851e8",
-                            "type": "default",
-                            "extras": {},
-                            "x": 2748.037637506487,
-                            "y": -3.037565800516151,
-                            "name": "parameter-string-message",
-                            "alignment": "left",
-                            "parentNode": "41aff0fa-745d-48dc-a878-9617f76afd85",
-                            "links": [],
-                            "in": true,
-                            "label": "message",
-                            "varName": "message",
-                            "portType": "",
-                            "dataType": "string"
-                        },
-                        {
-                            "id": "db00a5f1-e1a2-44cc-9451-0d1d3c839b7f",
-                            "type": "default",
-                            "extras": {},
-                            "x": 2748.037637506487,
-                            "y": 18.56244426728515,
-                            "name": "parameter-list-history",
-                            "alignment": "left",
-                            "parentNode": "41aff0fa-745d-48dc-a878-9617f76afd85",
-                            "links": [],
-                            "in": true,
-                            "label": "history",
-                            "varName": "history",
-                            "portType": "",
-                            "dataType": "list"
-                        },
-                        {
-                            "id": "65ccacc3-842c-424b-9d61-c88889e8189e",
-                            "type": "default",
-                            "extras": {},
-                            "x": 2748.037637506487,
-                            "y": 40.16245433508646,
-                            "name": "parameter-boolean-use_responses",
-                            "alignment": "left",
-                            "parentNode": "41aff0fa-745d-48dc-a878-9617f76afd85",
-                            "links": [],
-                            "in": true,
-                            "label": "use_responses",
-                            "varName": "use_responses",
-                            "portType": "",
-                            "dataType": "boolean"
-                        },
-                        {
-                            "id": "29d058d3-a4f5-4cc9-807b-a73f57c89cfd",
-                            "type": "default",
-                            "extras": {},
-                            "x": 2748.037637506487,
-                            "y": 61.76246440288776,
-                            "name": "parameter-boolean-use_openai",
-                            "alignment": "left",
-                            "parentNode": "41aff0fa-745d-48dc-a878-9617f76afd85",
-                            "links": [],
-                            "in": true,
-                            "label": "use_openai",
-                            "varName": "use_openai",
-                            "portType": "",
-                            "dataType": "boolean"
-                        },
-                        {
-                            "id": "9d96038e-5623-4e52-99cd-ae58b4115e28",
-                            "type": "default",
-                            "extras": {},
-                            "x": 2748.037637506487,
-                            "y": 83.36247447068907,
-                            "name": "parameter-boolean-use_agent",
-                            "alignment": "left",
-                            "parentNode": "41aff0fa-745d-48dc-a878-9617f76afd85",
-                            "links": [
-                                "7dd0ca4e-a249-486a-a5b3-af9410efa66e"
-                            ],
-                            "in": true,
-                            "label": "use_agent",
-                            "varName": "use_agent",
-                            "portType": "",
-                            "dataType": "boolean"
-                        },
-                        {
-                            "id": "8d19b2ac-8f6a-4e0b-b608-0c9bd274cb01",
-                            "type": "default",
-                            "extras": {},
-                            "x": 2748.037637506487,
-                            "y": 103.36246684356686,
-                            "name": "parameter-string-log_file",
-                            "alignment": "left",
-                            "parentNode": "41aff0fa-745d-48dc-a878-9617f76afd85",
-                            "links": [],
-                            "in": true,
-                            "label": "log_file",
-                            "varName": "log_file",
-                            "portType": "",
-                            "dataType": "string"
-                        },
-                        {
-                            "id": "afa5a99c-4040-4ecb-a5a9-494cf5622660",
-                            "type": "default",
-                            "extras": {},
-                            "x": 2880.9252926659874,
-                            "y": -67.83744346147608,
-                            "name": "out-0",
-                            "alignment": "right",
-                            "parentNode": "41aff0fa-745d-48dc-a878-9617f76afd85",
-                            "links": [],
-                            "in": false,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        }
-                    ],
-                    "name": "GradioFnReturn",
-                    "color": "purple",
-                    "portsInOrder": [
-                        "18bb550d-b233-4097-8a5e-087be6325ca2",
-                        "82ff7589-4960-4f01-8c76-09ab1762eb84",
-                        "1dc4deee-abf4-4cdc-b5fa-f3836d02d5d6",
-                        "34a6a1b5-6d97-4884-beb3-b42003a851e8",
-                        "db00a5f1-e1a2-44cc-9451-0d1d3c839b7f",
-                        "65ccacc3-842c-424b-9d61-c88889e8189e",
-                        "29d058d3-a4f5-4cc9-807b-a73f57c89cfd",
-                        "9d96038e-5623-4e52-99cd-ae58b4115e28",
-                        "8d19b2ac-8f6a-4e0b-b608-0c9bd274cb01"
-                    ],
-                    "portsOutOrder": [
-                        "afa5a99c-4040-4ecb-a5a9-494cf5622660"
-                    ]
-                },
-                "3c51c9e2-1b45-4818-bbf3-9c4d7893729f": {
-                    "id": "3c51c9e2-1b45-4818-bbf3-9c4d7893729f",
+                "8523af54-cfd0-49e4-8185-7784fe084c21": {
+                    "id": "8523af54-cfd0-49e4-8185-7784fe084c21",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -3558,21 +3387,20 @@
                                 "lineno": 146,
                                 "end_lineno": 198
                             }
-                        ],
-                        "borderColor": "rgb(0,192,255)"
+                        ]
                     },
                     "x": -127.24061204038067,
                     "y": 1126.3256569500593,
                     "ports": [
                         {
-                            "id": "1ecd39af-3a41-4c27-beeb-285d2fbf43c4",
+                            "id": "62b512e0-3c09-45a6-bded-f2d7b495157a",
                             "type": "default",
                             "extras": {},
-                            "x": -126.43747347767508,
-                            "y": 1153.125091732926,
+                            "x": -126.57280533358332,
+                            "y": 1152.98964834021,
                             "name": "parameter-string-tool_name",
                             "alignment": "left",
-                            "parentNode": "3c51c9e2-1b45-4818-bbf3-9c4d7893729f",
+                            "parentNode": "8523af54-cfd0-49e4-8185-7784fe084c21",
                             "links": [
                                 "0fb2ba66-7383-4289-bdd8-bbadbdf7c7d6"
                             ],
@@ -3583,14 +3411,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "5087d713-67e3-486b-97ab-594796075871",
+                            "id": "b52b4fef-b973-4764-b8d8-f3ed6af8b923",
                             "type": "default",
                             "extras": {},
-                            "x": -126.43747347767508,
-                            "y": 1174.7251018007273,
+                            "x": -126.57280533358332,
+                            "y": 1174.3230879476832,
                             "name": "parameter-string-description",
                             "alignment": "left",
-                            "parentNode": "3c51c9e2-1b45-4818-bbf3-9c4d7893729f",
+                            "parentNode": "8523af54-cfd0-49e4-8185-7784fe084c21",
                             "links": [
                                 "3dc4faa9-5335-4905-89c6-96efbc669d14"
                             ],
@@ -3601,14 +3429,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "bc26e355-b3c6-44b6-b08b-7c76ddc4e3fa",
+                            "id": "73d71bcc-91b6-4296-b905-be1d4e5f0675",
                             "type": "default",
                             "extras": {},
-                            "x": -126.43747347767508,
-                            "y": 1196.3251118685287,
+                            "x": -126.57280533358332,
+                            "y": 1195.656351733969,
                             "name": "parameter-string-for_toolbelt",
                             "alignment": "left",
-                            "parentNode": "3c51c9e2-1b45-4818-bbf3-9c4d7893729f",
+                            "parentNode": "8523af54-cfd0-49e4-8185-7784fe084c21",
                             "links": [
                                 "562eac0a-c234-49a5-a4b4-ce69754f37b6"
                             ],
@@ -3619,14 +3447,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "d1f17b75-d915-4a8c-a6d4-e1d472c42809",
+                            "id": "5ef1e615-846a-432e-ab2d-126f1c068a4c",
                             "type": "default",
                             "extras": {},
-                            "x": 33.87502497306573,
-                            "y": 1153.125091732926,
+                            "x": 33.83343538086022,
+                            "y": 1152.98964834021,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "3c51c9e2-1b45-4818-bbf3-9c4d7893729f",
+                            "parentNode": "8523af54-cfd0-49e4-8185-7784fe084c21",
                             "links": [
                                 "10981437-9f4a-4441-9597-8717da00f3a2"
                             ],
@@ -3637,14 +3465,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "a0f16440-d7e1-455c-908a-1c4ddd0f1121",
+                            "id": "c6e3392c-d9a5-42b1-a597-2d0ce927dfb0",
                             "type": "default",
                             "extras": {},
-                            "x": 33.87502497306573,
-                            "y": 1174.7251018007273,
+                            "x": 33.83343538086022,
+                            "y": 1174.3230879476832,
                             "name": "parameter-out-string-tool_input",
                             "alignment": "right",
-                            "parentNode": "3c51c9e2-1b45-4818-bbf3-9c4d7893729f",
+                            "parentNode": "8523af54-cfd0-49e4-8185-7784fe084c21",
                             "links": [
                                 "af8adecb-7bc3-4904-911e-bf61f790b080"
                             ],
@@ -3658,17 +3486,17 @@
                     "name": "AgentDefineTool",
                     "color": "red",
                     "portsInOrder": [
-                        "1ecd39af-3a41-4c27-beeb-285d2fbf43c4",
-                        "5087d713-67e3-486b-97ab-594796075871",
-                        "bc26e355-b3c6-44b6-b08b-7c76ddc4e3fa"
+                        "62b512e0-3c09-45a6-bded-f2d7b495157a",
+                        "b52b4fef-b973-4764-b8d8-f3ed6af8b923",
+                        "73d71bcc-91b6-4296-b905-be1d4e5f0675"
                     ],
                     "portsOutOrder": [
-                        "d1f17b75-d915-4a8c-a6d4-e1d472c42809",
-                        "a0f16440-d7e1-455c-908a-1c4ddd0f1121"
+                        "5ef1e615-846a-432e-ab2d-126f1c068a4c",
+                        "c6e3392c-d9a5-42b1-a597-2d0ce927dfb0"
                     ]
                 },
-                "11e4262d-dcc4-433d-899d-14d122497857": {
-                    "id": "11e4262d-dcc4-433d-899d-14d122497857",
+                "a18bb71c-0ba8-405d-9c0f-54de9fd3f954": {
+                    "id": "a18bb71c-0ba8-405d-9c0f-54de9fd3f954",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -3679,14 +3507,14 @@
                     "y": 1088.5613775124398,
                     "ports": [
                         {
-                            "id": "07d22c7e-58de-4830-b16e-7dded28f7db0",
+                            "id": "96631bd9-8cbd-4d7b-a099-d708d3412df2",
                             "type": "default",
                             "extras": {},
-                            "x": -317.8125711525087,
-                            "y": 1112.3500006936886,
+                            "x": -317.9478383733148,
+                            "y": 1112.88553875438,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "11e4262d-dcc4-433d-899d-14d122497857",
+                            "parentNode": "a18bb71c-0ba8-405d-9c0f-54de9fd3f954",
                             "links": [
                                 "0fb2ba66-7383-4289-bdd8-bbadbdf7c7d6"
                             ],
@@ -3701,11 +3529,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "07d22c7e-58de-4830-b16e-7dded28f7db0"
+                        "96631bd9-8cbd-4d7b-a099-d708d3412df2"
                     ]
                 },
-                "12121537-9b70-4983-9dbf-7ab890cfb8ef": {
-                    "id": "12121537-9b70-4983-9dbf-7ab890cfb8ef",
+                "ee568f94-4132-4278-ba48-b0207705b29e": {
+                    "id": "ee568f94-4132-4278-ba48-b0207705b29e",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -3716,14 +3544,14 @@
                     "y": 1221.8001246541414,
                     "ports": [
                         {
-                            "id": "3efa3ed2-9428-4698-bbec-fa23a1b933ff",
+                            "id": "b9c7ef9c-2bfd-429a-9e59-a7622bed4618",
                             "type": "default",
                             "extras": {},
-                            "x": -318.78746991199546,
-                            "y": 1245.600106233992,
+                            "x": -318.6560461165971,
+                            "y": 1246.1251203233967,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "12121537-9b70-4983-9dbf-7ab890cfb8ef",
+                            "parentNode": "ee568f94-4132-4278-ba48-b0207705b29e",
                             "links": [
                                 "562eac0a-c234-49a5-a4b4-ce69754f37b6"
                             ],
@@ -3738,11 +3566,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "3efa3ed2-9428-4698-bbec-fa23a1b933ff"
+                        "b9c7ef9c-2bfd-429a-9e59-a7622bed4618"
                     ]
                 },
-                "71dea741-3947-4377-894c-44f4ab5bfe52": {
-                    "id": "71dea741-3947-4377-894c-44f4ab5bfe52",
+                "1754e07e-0300-4b92-83d5-0ec692303f0e": {
+                    "id": "1754e07e-0300-4b92-83d5-0ec692303f0e",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -3754,21 +3582,20 @@
                                 "lineno": 201,
                                 "end_lineno": 213
                             }
-                        ],
-                        "borderColor": "rgb(0,192,255)"
+                        ]
                     },
                     "x": 483.96531921431836,
                     "y": 1124.3272231308536,
                     "ports": [
                         {
-                            "id": "2cf08fab-5205-4cfd-af0f-f88db9c508cf",
+                            "id": "6aa45db2-4cfb-42e3-8515-f175074ea474",
                             "type": "default",
                             "extras": {},
-                            "x": 484.7624978443455,
-                            "y": 1151.1250696142715,
+                            "x": 484.6248944564276,
+                            "y": 1150.989682332306,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "71dea741-3947-4377-894c-44f4ab5bfe52",
+                            "parentNode": "1754e07e-0300-4b92-83d5-0ec692303f0e",
                             "links": [
                                 "5819af48-c165-4108-9bb1-a5075a1537fc"
                             ],
@@ -3779,14 +3606,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "4f52067f-0d74-4f7b-8488-5c03ca205d08",
+                            "id": "239c1bf2-f0df-4af2-bfc2-bf0ff1db71b9",
                             "type": "default",
                             "extras": {},
-                            "x": 484.7624978443455,
-                            "y": 1172.7250796820729,
+                            "x": 484.6248944564276,
+                            "y": 1172.322946118592,
                             "name": "parameter-dynalist-results",
                             "alignment": "left",
-                            "parentNode": "71dea741-3947-4377-894c-44f4ab5bfe52",
+                            "parentNode": "1754e07e-0300-4b92-83d5-0ec692303f0e",
                             "links": [
                                 "f0128e69-2aad-49be-b112-a8cf6841f19c"
                             ],
@@ -3798,18 +3625,18 @@
                             "dynaPortOrder": 0,
                             "dynaPortRef": {
                                 "previous": null,
-                                "next": "6be623e8-5825-4cfb-89a9-0e5d7adb1f93"
+                                "next": "b8561eb5-0f08-4ebb-bfbb-08e5073c8f09"
                             }
                         },
                         {
-                            "id": "6be623e8-5825-4cfb-89a9-0e5d7adb1f93",
+                            "id": "b8561eb5-0f08-4ebb-bfbb-08e5073c8f09",
                             "type": "default",
                             "extras": {},
-                            "x": 484.7624978443455,
-                            "y": 1194.3250897498742,
+                            "x": 484.6248944564276,
+                            "y": 1193.6563857260653,
                             "name": "parameter-dynalist-results-1",
                             "alignment": "left",
-                            "parentNode": "71dea741-3947-4377-894c-44f4ab5bfe52",
+                            "parentNode": "1754e07e-0300-4b92-83d5-0ec692303f0e",
                             "links": [],
                             "in": true,
                             "label": "results[1]",
@@ -3818,19 +3645,19 @@
                             "dataType": "dynalist",
                             "dynaPortOrder": 1,
                             "dynaPortRef": {
-                                "previous": "4f52067f-0d74-4f7b-8488-5c03ca205d08",
+                                "previous": "239c1bf2-f0df-4af2-bfc2-bf0ff1db71b9",
                                 "next": null
                             }
                         },
                         {
-                            "id": "da9b76ef-e393-4065-be16-57e17902a715",
+                            "id": "5c280e79-82b5-4871-b6c9-5c1647729c81",
                             "type": "default",
                             "extras": {},
-                            "x": 621.1250698777477,
-                            "y": 1151.1250696142715,
+                            "x": 621.2397153620357,
+                            "y": 1150.989682332306,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "71dea741-3947-4377-894c-44f4ab5bfe52",
+                            "parentNode": "1754e07e-0300-4b92-83d5-0ec692303f0e",
                             "links": [],
                             "in": false,
                             "label": "▶",
@@ -3842,16 +3669,16 @@
                     "name": "AgentToolOutput",
                     "color": "red",
                     "portsInOrder": [
-                        "2cf08fab-5205-4cfd-af0f-f88db9c508cf",
-                        "4f52067f-0d74-4f7b-8488-5c03ca205d08",
-                        "6be623e8-5825-4cfb-89a9-0e5d7adb1f93"
+                        "6aa45db2-4cfb-42e3-8515-f175074ea474",
+                        "239c1bf2-f0df-4af2-bfc2-bf0ff1db71b9",
+                        "b8561eb5-0f08-4ebb-bfbb-08e5073c8f09"
                     ],
                     "portsOutOrder": [
-                        "da9b76ef-e393-4065-be16-57e17902a715"
+                        "5c280e79-82b5-4871-b6c9-5c1647729c81"
                     ]
                 },
-                "b71100b5-7f7e-4c82-9be7-40c507dfce75": {
-                    "id": "b71100b5-7f7e-4c82-9be7-40c507dfce75",
+                "2eaca646-a1e9-47f9-95be-364600f39f33": {
+                    "id": "2eaca646-a1e9-47f9-95be-364600f39f33",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -3862,14 +3689,14 @@
                     "y": 1148.855452133661,
                     "ports": [
                         {
-                            "id": "15929f8f-5152-48d3-aef2-2d8aa064a5cf",
+                            "id": "960c62be-352a-44e3-965b-11c3a241fe3a",
                             "type": "default",
                             "extras": {},
-                            "x": -317.8125711525087,
-                            "y": 1180.350009083523,
+                            "x": -317.9582118233778,
+                            "y": 1182.0208911791594,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "b71100b5-7f7e-4c82-9be7-40c507dfce75",
+                            "parentNode": "2eaca646-a1e9-47f9-95be-364600f39f33",
                             "links": [
                                 "3dc4faa9-5335-4905-89c6-96efbc669d14"
                             ],
@@ -3884,65 +3711,29 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "15929f8f-5152-48d3-aef2-2d8aa064a5cf"
+                        "960c62be-352a-44e3-965b-11c3a241fe3a"
                     ]
                 },
-                "4682114a-3217-4ecb-acf2-bd358b27eae4": {
-                    "id": "4682114a-3217-4ecb-acf2-bd358b27eae4",
+                "bf761ee7-8ae7-4523-b8bd-2e239df1408b": {
+                    "id": "bf761ee7-8ae7-4523-b8bd-2e239df1408b",
                     "type": "custom-node",
-                    "selected": false,
-                    "extras": {
-                        "type": "string"
-                    },
-                    "x": -480.1417789685624,
-                    "y": 220.53542322539872,
-                    "ports": [
-                        {
-                            "id": "18b128c1-f5fa-4f4b-ae8e-6442e5bfb698",
-                            "type": "default",
-                            "extras": {},
-                            "x": -350.5375779311136,
-                            "y": 244.32503254645766,
-                            "name": "parameter-out-0",
-                            "alignment": "right",
-                            "parentNode": "4682114a-3217-4ecb-acf2-bd358b27eae4",
-                            "links": [
-                                "0cc96856-42f8-4d89-83e0-9f53fe3ed0ca"
-                            ],
-                            "in": false,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": "string"
-                        }
-                    ],
-                    "name": "Argument (string): api_key",
-                    "color": "lightpink",
-                    "portsInOrder": [],
-                    "portsOutOrder": [
-                        "18b128c1-f5fa-4f4b-ae8e-6442e5bfb698"
-                    ]
-                },
-                "507ae692-69b1-4bf1-8cb1-698b360ff0ba": {
-                    "id": "507ae692-69b1-4bf1-8cb1-698b360ff0ba",
-                    "type": "custom-node",
-                    "selected": false,
+                    "selected": true,
                     "extras": {
                         "type": "string",
                         "attached": false
                     },
-                    "x": 489.51950532063086,
-                    "y": 203.4485975913816,
+                    "x": 487.19649913738505,
+                    "y": 217.38663469085657,
                     "ports": [
                         {
-                            "id": "6149dbe2-9e5b-4b03-86e6-64cf47b176ef",
+                            "id": "5b1d2330-bf8d-43b7-9a1e-8c107228f223",
                             "type": "default",
                             "extras": {},
-                            "x": 755.0126407575477,
-                            "y": 438.93753850991385,
+                            "x": 752.5522400620746,
+                            "y": 465.88597420723073,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "507ae692-69b1-4bf1-8cb1-698b360ff0ba",
+                            "parentNode": "bf761ee7-8ae7-4523-b8bd-2e239df1408b",
                             "links": [
                                 "cbda0e1d-fb8c-48d5-b495-bcfc9032fdaf"
                             ],
@@ -3957,11 +3748,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "6149dbe2-9e5b-4b03-86e6-64cf47b176ef"
+                        "5b1d2330-bf8d-43b7-9a1e-8c107228f223"
                     ]
                 },
-                "3b872944-98ca-4ddf-9a47-cb608a2684db": {
-                    "id": "3b872944-98ca-4ddf-9a47-cb608a2684db",
+                "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a": {
+                    "id": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -3975,18 +3766,18 @@
                             }
                         ]
                     },
-                    "x": 1014.6760973319774,
-                    "y": 21.43893342663818,
+                    "x": 1019.9326612190883,
+                    "y": 16.18236953952725,
                     "ports": [
                         {
-                            "id": "54ea82f5-baa1-4fc4-9580-eb5ea007fafd",
+                            "id": "e17e1b08-093d-42cc-9e51-71d9ae20ed1f",
                             "type": "default",
                             "extras": {},
-                            "x": 1015.4750502951115,
-                            "y": 48.23744114969895,
+                            "x": 1020.5939827473812,
+                            "y": 42.843769500934236,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "3b872944-98ca-4ddf-9a47-cb608a2684db",
+                            "parentNode": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
                             "links": [
                                 "35c0974f-328c-438b-b69e-e7cb8727f4f0"
                             ],
@@ -3997,14 +3788,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "5bd60d52-b2cc-4577-8c11-9775c8c179e6",
+                            "id": "446418e2-5fa4-4ac2-b8d5-f6bc950673b5",
                             "type": "default",
                             "extras": {},
-                            "x": 1015.4750502951115,
-                            "y": 69.83745121750026,
+                            "x": 1020.5939827473812,
+                            "y": 64.17712119781382,
                             "name": "parameter-string-agent_name",
                             "alignment": "left",
-                            "parentNode": "3b872944-98ca-4ddf-9a47-cb608a2684db",
+                            "parentNode": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
                             "links": [
                                 "2c55f47c-f510-420c-bbfb-df5fd16bce7c"
                             ],
@@ -4015,14 +3806,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "ddd8de9b-6638-4212-8ba8-79269a7e3194",
+                            "id": "6fa4a4b9-7f76-43b4-a0db-2485937c92e5",
                             "type": "default",
                             "extras": {},
-                            "x": 1015.4750502951115,
-                            "y": 89.83744359037806,
+                            "x": 1020.5939827473812,
+                            "y": 84.17713291922632,
                             "name": "parameter-string-agent_provider",
                             "alignment": "left",
-                            "parentNode": "3b872944-98ca-4ddf-9a47-cb608a2684db",
+                            "parentNode": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
                             "links": [
                                 "6e6ceca9-1911-4e82-a8c0-c62abb44bd97"
                             ],
@@ -4033,14 +3824,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "7df3655d-750f-43a4-ab93-a1a06065f01f",
+                            "id": "2330e3dd-9b31-4db8-8723-1c91be06d3e8",
                             "type": "default",
                             "extras": {},
-                            "x": 1015.4750502951115,
-                            "y": 109.83743596325586,
+                            "x": 1020.5939827473812,
+                            "y": 104.17714464063883,
                             "name": "parameter-string-agent_model",
                             "alignment": "left",
-                            "parentNode": "3b872944-98ca-4ddf-9a47-cb608a2684db",
+                            "parentNode": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
                             "links": [
                                 "961320c7-b2bd-4170-8caf-ce9c7eae2fff"
                             ],
@@ -4051,14 +3842,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "19aa22af-5306-4343-aac9-6989f6292ad3",
+                            "id": "f9e89463-01da-45bd-9aed-c42d28232df9",
                             "type": "default",
                             "extras": {},
-                            "x": 1015.4750502951115,
-                            "y": 129.83750460735564,
+                            "x": 1020.5939827473812,
+                            "y": 124.17715636205132,
                             "name": "parameter-Memory-agent_memory",
                             "alignment": "left",
-                            "parentNode": "3b872944-98ca-4ddf-9a47-cb608a2684db",
+                            "parentNode": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
                             "links": [
                                 "acaf4f91-8afe-4639-a76f-450e5997e6bf"
                             ],
@@ -4069,14 +3860,14 @@
                             "dataType": "Memory"
                         },
                         {
-                            "id": "cfbe31dc-0198-4054-a430-349517d9389a",
+                            "id": "d676331c-d951-4a23-a1cf-14ea927026be",
                             "type": "default",
                             "extras": {},
-                            "x": 1015.4750502951115,
-                            "y": 151.43751467515696,
+                            "x": 1020.5939827473812,
+                            "y": 145.51050805893092,
                             "name": "parameter-string-system_prompt",
                             "alignment": "left",
-                            "parentNode": "3b872944-98ca-4ddf-9a47-cb608a2684db",
+                            "parentNode": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
                             "links": [
                                 "cbda0e1d-fb8c-48d5-b495-bcfc9032fdaf"
                             ],
@@ -4087,14 +3878,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "10d32b90-2e7c-47ae-aabc-1047f7dd19cb",
+                            "id": "d37ca8bd-540a-4727-b3fd-a8933113f8ec",
                             "type": "default",
                             "extras": {},
-                            "x": 1015.4750502951115,
-                            "y": 173.03752474295825,
+                            "x": 1020.5939827473812,
+                            "y": 166.84377184521674,
                             "name": "parameter-int-max_thoughts",
                             "alignment": "left",
-                            "parentNode": "3b872944-98ca-4ddf-9a47-cb608a2684db",
+                            "parentNode": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
                             "links": [
                                 "3bcb0615-0fd9-4c36-80a3-1d960540b388"
                             ],
@@ -4105,14 +3896,14 @@
                             "dataType": "int"
                         },
                         {
-                            "id": "78611fb3-94f9-4b79-b2a7-9d4997960edf",
+                            "id": "3c40c46a-5af8-4c20-8205-d3c810baa620",
                             "type": "default",
                             "extras": {},
-                            "x": 1015.4750502951115,
-                            "y": 194.63753481075958,
+                            "x": 1020.5939827473812,
+                            "y": 186.84378356662924,
                             "name": "parameter-dict-toolbelt_spec",
                             "alignment": "left",
-                            "parentNode": "3b872944-98ca-4ddf-9a47-cb608a2684db",
+                            "parentNode": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
                             "links": [
                                 "cfb49a15-7c9d-4132-a8bd-ec2fb861889a"
                             ],
@@ -4123,14 +3914,14 @@
                             "dataType": "dict"
                         },
                         {
-                            "id": "3e300b46-b87c-492b-83c3-bdffbb409882",
+                            "id": "3c7f7c1a-d7ab-4af5-a37c-7cf682cb327f",
                             "type": "default",
                             "extras": {},
-                            "x": 1199.0251019497966,
-                            "y": 48.23744114969895,
+                            "x": 1204.500131741772,
+                            "y": 42.843769500934236,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "3b872944-98ca-4ddf-9a47-cb608a2684db",
+                            "parentNode": "6e7a544e-fe3f-43e8-bd0c-51875ea6a60a",
                             "links": [
                                 "18df1d85-cdb1-4140-a26a-abcc297d1fd9"
                             ],
@@ -4142,23 +3933,23 @@
                         }
                     ],
                     "name": "AgentInit",
-                    "color": "rgb(51,51,51)",
+                    "color": "rgb(255,102,102)",
                     "portsInOrder": [
-                        "54ea82f5-baa1-4fc4-9580-eb5ea007fafd",
-                        "5bd60d52-b2cc-4577-8c11-9775c8c179e6",
-                        "ddd8de9b-6638-4212-8ba8-79269a7e3194",
-                        "7df3655d-750f-43a4-ab93-a1a06065f01f",
-                        "19aa22af-5306-4343-aac9-6989f6292ad3",
-                        "cfbe31dc-0198-4054-a430-349517d9389a",
-                        "10d32b90-2e7c-47ae-aabc-1047f7dd19cb",
-                        "78611fb3-94f9-4b79-b2a7-9d4997960edf"
+                        "e17e1b08-093d-42cc-9e51-71d9ae20ed1f",
+                        "446418e2-5fa4-4ac2-b8d5-f6bc950673b5",
+                        "6fa4a4b9-7f76-43b4-a0db-2485937c92e5",
+                        "2330e3dd-9b31-4db8-8723-1c91be06d3e8",
+                        "f9e89463-01da-45bd-9aed-c42d28232df9",
+                        "d676331c-d951-4a23-a1cf-14ea927026be",
+                        "d37ca8bd-540a-4727-b3fd-a8933113f8ec",
+                        "3c40c46a-5af8-4c20-8205-d3c810baa620"
                     ],
                     "portsOutOrder": [
-                        "3e300b46-b87c-492b-83c3-bdffbb409882"
+                        "3c7f7c1a-d7ab-4af5-a37c-7cf682cb327f"
                     ]
                 },
-                "b7c17027-db3a-460f-95fb-8025213ecfc5": {
-                    "id": "b7c17027-db3a-460f-95fb-8025213ecfc5",
+                "789af1b0-821f-4b8d-b1f4-d3b053c889de": {
+                    "id": "789af1b0-821f-4b8d-b1f4-d3b053c889de",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -4176,14 +3967,14 @@
                     "y": 24.549145190211,
                     "ports": [
                         {
-                            "id": "62cfce43-5e51-4e23-a295-3c41b58ca9d8",
+                            "id": "b193a307-70a9-463f-ab82-0ed7abe19f3a",
                             "type": "default",
                             "extras": {},
-                            "x": 322.4249984497483,
-                            "y": 51.337408696294,
+                            "x": 322.29182934808364,
+                            "y": 51.20837458603462,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "b7c17027-db3a-460f-95fb-8025213ecfc5",
+                            "parentNode": "789af1b0-821f-4b8d-b1f4-d3b053c889de",
                             "links": [
                                 "1fa0339c-bd91-423e-b9dc-c0d0e78d212e"
                             ],
@@ -4194,14 +3985,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "b1d3603c-28b6-4738-adf4-2339cfe820dd",
+                            "id": "a0f60c18-ef28-4f01-b19f-05d5cc4666a9",
                             "type": "default",
                             "extras": {},
-                            "x": 322.4249984497483,
-                            "y": 72.9374187640953,
+                            "x": 322.29182934808364,
+                            "y": 72.54168232761732,
                             "name": "parameter-string-name",
                             "alignment": "left",
-                            "parentNode": "b7c17027-db3a-460f-95fb-8025213ecfc5",
+                            "parentNode": "789af1b0-821f-4b8d-b1f4-d3b053c889de",
                             "links": [
                                 "59948ccc-8d0d-4104-ad20-4757522ddb7b"
                             ],
@@ -4212,14 +4003,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "5bf7092a-334c-46b1-8249-b85acc7eefd1",
+                            "id": "ab64bf4f-1f63-4dbc-a6e9-81ebd0deb1d0",
                             "type": "default",
                             "extras": {},
-                            "x": 503.9125237193575,
-                            "y": 51.337408696294,
+                            "x": 503.78149194136415,
+                            "y": 51.20837458603462,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "b7c17027-db3a-460f-95fb-8025213ecfc5",
+                            "parentNode": "789af1b0-821f-4b8d-b1f4-d3b053c889de",
                             "links": [
                                 "35c0974f-328c-438b-b69e-e7cb8727f4f0"
                             ],
@@ -4230,14 +4021,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "3f4c45a1-e964-4e09-8d0b-47945974a0f1",
+                            "id": "f596926d-2df4-4315-86af-4a300a40e583",
                             "type": "default",
                             "extras": {},
-                            "x": 503.9125237193575,
-                            "y": 72.9374187640953,
+                            "x": 503.78149194136415,
+                            "y": 72.54168232761732,
                             "name": "parameter-out-dict-toolbelt_spec",
                             "alignment": "right",
-                            "parentNode": "b7c17027-db3a-460f-95fb-8025213ecfc5",
+                            "parentNode": "789af1b0-821f-4b8d-b1f4-d3b053c889de",
                             "links": [
                                 "cfb49a15-7c9d-4132-a8bd-ec2fb861889a"
                             ],
@@ -4249,37 +4040,36 @@
                         }
                     ],
                     "name": "AgentMakeToolbelt",
-                    "color": "rgb(102,102,102)",
+                    "color": "rgb(0,102,204)",
                     "portsInOrder": [
-                        "62cfce43-5e51-4e23-a295-3c41b58ca9d8",
-                        "b1d3603c-28b6-4738-adf4-2339cfe820dd"
+                        "b193a307-70a9-463f-ab82-0ed7abe19f3a",
+                        "a0f60c18-ef28-4f01-b19f-05d5cc4666a9"
                     ],
                     "portsOutOrder": [
-                        "5bf7092a-334c-46b1-8249-b85acc7eefd1",
-                        "3f4c45a1-e964-4e09-8d0b-47945974a0f1"
+                        "ab64bf4f-1f63-4dbc-a6e9-81ebd0deb1d0",
+                        "f596926d-2df4-4315-86af-4a300a40e583"
                     ]
                 },
-                "6b843293-5419-4d8b-b9cf-d2432b7fbf01": {
-                    "id": "6b843293-5419-4d8b-b9cf-d2432b7fbf01",
+                "c426ad10-584a-4395-976d-8adf25202a16": {
+                    "id": "c426ad10-584a-4395-976d-8adf25202a16",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
                         "type": "string",
-                        "attached": false,
-                        "borderColor": "rgb(0,192,255)"
+                        "attached": false
                     },
-                    "x": -171.1033643407034,
-                    "y": 1364.094616666893,
+                    "x": -127.03022101824418,
+                    "y": 1331.7930671961858,
                     "ports": [
                         {
-                            "id": "5fcfc361-c856-4504-877c-182ba0d35d1c",
+                            "id": "3c1a5f92-0e86-4bb6-81f0-3319cbdbf81b",
                             "type": "default",
                             "extras": {},
-                            "x": 83.91253134647971,
-                            "y": 1387.8875468592291,
+                            "x": 127.8645404932129,
+                            "y": 1356.125008969978,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "6b843293-5419-4d8b-b9cf-d2432b7fbf01",
+                            "parentNode": "c426ad10-584a-4395-976d-8adf25202a16",
                             "links": [
                                 "6c4f75f8-0732-40ac-9861-d7d3d6fc83f3"
                             ],
@@ -4294,11 +4084,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "5fcfc361-c856-4504-877c-182ba0d35d1c"
+                        "3c1a5f92-0e86-4bb6-81f0-3319cbdbf81b"
                     ]
                 },
-                "5bfa0140-dfc0-4e82-9f57-4037e08fe65c": {
-                    "id": "5bfa0140-dfc0-4e82-9f57-4037e08fe65c",
+                "8e871605-ef71-44a4-b813-8f32cc7f7ee1": {
+                    "id": "8e871605-ef71-44a4-b813-8f32cc7f7ee1",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -4310,21 +4100,20 @@
                                 "lineno": 7,
                                 "end_lineno": 60
                             }
-                        ],
-                        "borderColor": "rgb(0,192,255)"
+                        ]
                     },
                     "x": 181.30717688637762,
                     "y": 1126.086004868006,
                     "ports": [
                         {
-                            "id": "1c076e9d-5263-49d3-ba61-ec469c098aff",
+                            "id": "11ba0d3c-f94c-4cfc-80fd-ac3b78682ded",
                             "type": "default",
                             "extras": {},
-                            "x": 182.0999838914788,
-                            "y": 1152.8750365316291,
+                            "x": 181.9687637767439,
+                            "y": 1152.7501798828239,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "5bfa0140-dfc0-4e82-9f57-4037e08fe65c",
+                            "parentNode": "8e871605-ef71-44a4-b813-8f32cc7f7ee1",
                             "links": [
                                 "10981437-9f4a-4441-9597-8717da00f3a2"
                             ],
@@ -4335,14 +4124,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "db9450ad-668c-4a2c-9364-19503cce6cd0",
+                            "id": "46506216-7b9f-4aad-bb80-b2837a64f635",
                             "type": "default",
                             "extras": {},
-                            "x": 182.0999838914788,
-                            "y": 1174.4750465994302,
+                            "x": 181.9687637767439,
+                            "y": 1174.0834436691098,
                             "name": "parameter-string-city",
                             "alignment": "left",
-                            "parentNode": "5bfa0140-dfc0-4e82-9f57-4037e08fe65c",
+                            "parentNode": "8e871605-ef71-44a4-b813-8f32cc7f7ee1",
                             "links": [
                                 "af8adecb-7bc3-4904-911e-bf61f790b080"
                             ],
@@ -4353,15 +4142,17 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "e0dfa572-23c1-452a-87ec-c78108a607cc",
+                            "id": "dcb5e435-b068-46d5-998c-66356de88421",
                             "type": "default",
                             "extras": {},
-                            "x": 182.0999838914788,
-                            "y": 1196.0750566672316,
+                            "x": 181.9687637767439,
+                            "y": 1195.4167074553955,
                             "name": "parameter-string-api_key",
                             "alignment": "left",
-                            "parentNode": "5bfa0140-dfc0-4e82-9f57-4037e08fe65c",
-                            "links": [],
+                            "parentNode": "8e871605-ef71-44a4-b813-8f32cc7f7ee1",
+                            "links": [
+                                "15b071f0-8734-455e-b5b5-f588001173fc"
+                            ],
                             "in": true,
                             "label": "api_key",
                             "varName": "api_key",
@@ -4369,14 +4160,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "49cf4bac-81a7-4f75-8192-e3016154cd1f",
+                            "id": "df9225b1-fad9-4972-9272-67038705ad0b",
                             "type": "default",
                             "extras": {},
-                            "x": 182.0999838914788,
-                            "y": 1217.675066735033,
+                            "x": 181.9687637767439,
+                            "y": 1216.7501470628688,
                             "name": "parameter-string-url",
                             "alignment": "left",
-                            "parentNode": "5bfa0140-dfc0-4e82-9f57-4037e08fe65c",
+                            "parentNode": "8e871605-ef71-44a4-b813-8f32cc7f7ee1",
                             "links": [
                                 "6c4f75f8-0732-40ac-9861-d7d3d6fc83f3"
                             ],
@@ -4387,14 +4178,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "2be15f97-c738-458e-9d68-9ed7fbe7e807",
+                            "id": "73ed47f7-c86b-44c4-8237-2e22d1be8917",
                             "type": "default",
                             "extras": {},
-                            "x": 333.6124612913623,
-                            "y": 1152.8750365316291,
+                            "x": 333.2083910592692,
+                            "y": 1152.7501798828239,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "5bfa0140-dfc0-4e82-9f57-4037e08fe65c",
+                            "parentNode": "8e871605-ef71-44a4-b813-8f32cc7f7ee1",
                             "links": [
                                 "5819af48-c165-4108-9bb1-a5075a1537fc"
                             ],
@@ -4405,14 +4196,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "da54dd08-7936-41f6-9178-65152919cb54",
+                            "id": "3e4eab61-097b-4c2b-818c-6e3660356381",
                             "type": "default",
                             "extras": {},
-                            "x": 333.6124612913623,
-                            "y": 1174.4750465994302,
+                            "x": 333.2083910592692,
+                            "y": 1174.0834436691098,
                             "name": "parameter-out-string-weather_info",
                             "alignment": "right",
-                            "parentNode": "5bfa0140-dfc0-4e82-9f57-4037e08fe65c",
+                            "parentNode": "8e871605-ef71-44a4-b813-8f32cc7f7ee1",
                             "links": [
                                 "f0128e69-2aad-49be-b112-a8cf6841f19c"
                             ],
@@ -4424,17 +4215,428 @@
                         }
                     ],
                     "name": "GetWeather",
-                    "color": "rgb(102,102,102)",
+                    "color": "rgb(15,255,255)",
                     "portsInOrder": [
-                        "1c076e9d-5263-49d3-ba61-ec469c098aff",
-                        "db9450ad-668c-4a2c-9364-19503cce6cd0",
-                        "e0dfa572-23c1-452a-87ec-c78108a607cc",
-                        "49cf4bac-81a7-4f75-8192-e3016154cd1f"
+                        "11ba0d3c-f94c-4cfc-80fd-ac3b78682ded",
+                        "46506216-7b9f-4aad-bb80-b2837a64f635",
+                        "dcb5e435-b068-46d5-998c-66356de88421",
+                        "df9225b1-fad9-4972-9272-67038705ad0b"
                     ],
                     "portsOutOrder": [
-                        "2be15f97-c738-458e-9d68-9ed7fbe7e807",
-                        "da54dd08-7936-41f6-9178-65152919cb54"
+                        "73ed47f7-c86b-44c4-8237-2e22d1be8917",
+                        "3e4eab61-097b-4c2b-818c-6e3660356381"
                     ]
+                },
+                "b51635e5-1d86-49ed-9996-61992c3f9209": {
+                    "id": "b51635e5-1d86-49ed-9996-61992c3f9209",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "library_component",
+                        "path": "xai_components/xai_gradio/gradio_component.py",
+                        "description": "Handles the chat history and appends responses from a OpenAI-like Chat to it.\nInternally updates `ctx['__gradio_chat_history__']` for `GradioChatInterface` to process.\n\n##### inPorts:\n- message (str): The user's message just sent.\n- history (list): The conversation so far. Typically connected from the `GradioChatInterface` component.\n- llm_response (str/dict): The raw LLM response from the model.\n- log_file (str): Path to optionally log the conversation.\n\n##### outPorts:",
+                        "lineNo": [
+                            {
+                                "lineno": 249,
+                                "end_lineno": 292
+                            }
+                        ],
+                        "nextNode": "None"
+                    },
+                    "x": 2902.6360899016863,
+                    "y": -35.24260180206869,
+                    "ports": [
+                        {
+                            "id": "b4a8749c-9a69-4dd4-83ca-b2b347a2b02c",
+                            "type": "default",
+                            "extras": {},
+                            "x": 2903.30202756303,
+                            "y": -8.572895065646028,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "b51635e5-1d86-49ed-9996-61992c3f9209",
+                            "links": [
+                                "584f34af-e97b-44af-aa0a-0bd8155d42cf"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "b14cb31d-6ea8-47d4-9fcf-fa30fbd3d5a6",
+                            "type": "default",
+                            "extras": {},
+                            "x": 2903.30202756303,
+                            "y": 12.76041267593668,
+                            "name": "parameter-string-message",
+                            "alignment": "left",
+                            "parentNode": "b51635e5-1d86-49ed-9996-61992c3f9209",
+                            "links": [
+                                "32449492-6723-426b-9bc3-1d01a04cc893"
+                            ],
+                            "in": true,
+                            "label": "message",
+                            "varName": "message",
+                            "portType": "",
+                            "dataType": "string"
+                        },
+                        {
+                            "id": "69cfaf6c-c084-4cef-b8b8-0d7ffdc23133",
+                            "type": "default",
+                            "extras": {},
+                            "x": 2903.30202756303,
+                            "y": 34.09376437281627,
+                            "name": "parameter-list-history",
+                            "alignment": "left",
+                            "parentNode": "b51635e5-1d86-49ed-9996-61992c3f9209",
+                            "links": [
+                                "935964df-7e09-4c1e-ad42-f95f83c5a53a"
+                            ],
+                            "in": true,
+                            "label": "history",
+                            "varName": "history",
+                            "portType": "",
+                            "dataType": "list"
+                        },
+                        {
+                            "id": "052cca44-5117-47ee-bbb7-b518f47f8abd",
+                            "type": "default",
+                            "extras": {},
+                            "x": 2903.30202756303,
+                            "y": 55.427072114398975,
+                            "name": "parameter-any-llm_response",
+                            "alignment": "left",
+                            "parentNode": "b51635e5-1d86-49ed-9996-61992c3f9209",
+                            "links": [
+                                "62e4919b-12d7-4823-8dfe-fabfb204013f"
+                            ],
+                            "in": true,
+                            "label": "llm_response",
+                            "varName": "llm_response",
+                            "portType": "",
+                            "dataType": "any"
+                        },
+                        {
+                            "id": "c1aaea9b-9c91-4783-9d4d-b699e8fa1e3e",
+                            "type": "default",
+                            "extras": {},
+                            "x": 2903.30202756303,
+                            "y": 76.76046776657543,
+                            "name": "parameter-string-log_file",
+                            "alignment": "left",
+                            "parentNode": "b51635e5-1d86-49ed-9996-61992c3f9209",
+                            "links": [],
+                            "in": true,
+                            "label": "log_file",
+                            "varName": "log_file",
+                            "portType": "",
+                            "dataType": "string"
+                        },
+                        {
+                            "id": "1f0467d0-047b-485f-a8a6-d05b9c2fc33d",
+                            "type": "default",
+                            "extras": {},
+                            "x": 3061.291430233988,
+                            "y": -8.572895065646028,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "b51635e5-1d86-49ed-9996-61992c3f9209",
+                            "links": [],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        }
+                    ],
+                    "name": "GradioChatFnReturn",
+                    "color": "purple",
+                    "portsInOrder": [
+                        "b4a8749c-9a69-4dd4-83ca-b2b347a2b02c",
+                        "b14cb31d-6ea8-47d4-9fcf-fa30fbd3d5a6",
+                        "69cfaf6c-c084-4cef-b8b8-0d7ffdc23133",
+                        "052cca44-5117-47ee-bbb7-b518f47f8abd",
+                        "c1aaea9b-9c91-4783-9d4d-b699e8fa1e3e"
+                    ],
+                    "portsOutOrder": [
+                        "1f0467d0-047b-485f-a8a6-d05b9c2fc33d"
+                    ]
+                },
+                "de0a966a-06ae-4eef-b06b-d672c27a5a2f": {
+                    "id": "de0a966a-06ae-4eef-b06b-d672c27a5a2f",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "secret"
+                    },
+                    "x": -89.61352021060654,
+                    "y": 1264.0404268463897,
+                    "ports": [
+                        {
+                            "id": "b290d782-14c2-4983-a1bf-45c34ecacb8b",
+                            "type": "default",
+                            "extras": {},
+                            "x": 117.70840541799953,
+                            "y": 1288.3645782315114,
+                            "name": "parameter-out-0",
+                            "alignment": "right",
+                            "parentNode": "de0a966a-06ae-4eef-b06b-d672c27a5a2f",
+                            "links": [
+                                "15b071f0-8734-455e-b5b5-f588001173fc"
+                            ],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": "secret"
+                        }
+                    ],
+                    "name": "Argument (secret): openweather_api_key",
+                    "color": "black",
+                    "portsInOrder": [],
+                    "portsOutOrder": [
+                        "b290d782-14c2-4983-a1bf-45c34ecacb8b"
+                    ]
+                },
+                "891e6f05-40a9-4cf2-b1e7-4c51d0e2cae6": {
+                    "id": "891e6f05-40a9-4cf2-b1e7-4c51d0e2cae6",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "secret"
+                    },
+                    "x": -456.125847852149,
+                    "y": 171.39420437173231,
+                    "ports": [
+                        {
+                            "id": "93569724-e064-415c-ad23-0a5ba157cc7b",
+                            "type": "default",
+                            "extras": {},
+                            "x": -281.37492151739616,
+                            "y": 195.71879755906542,
+                            "name": "parameter-out-0",
+                            "alignment": "right",
+                            "parentNode": "891e6f05-40a9-4cf2-b1e7-4c51d0e2cae6",
+                            "links": [
+                                "a7ce3ded-ad54-4dce-8010-54a5fa121b9c"
+                            ],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": "secret"
+                        }
+                    ],
+                    "name": "Argument (secret): openai_api_key",
+                    "color": "black",
+                    "portsInOrder": [],
+                    "portsOutOrder": [
+                        "93569724-e064-415c-ad23-0a5ba157cc7b"
+                    ]
+                },
+                "c304a0df-a115-4489-8114-73a0c87ae1d0": {
+                    "id": "c304a0df-a115-4489-8114-73a0c87ae1d0",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "library_component",
+                        "path": "xai_components/xai_utils/utils.py",
+                        "description": "Prints a message to the console.\n\n##### inPorts:\n- msg (any): The message to be printed.",
+                        "lineNo": [
+                            {
+                                "lineno": 52,
+                                "end_lineno": 61
+                            }
+                        ]
+                    },
+                    "x": 2691.6730749354256,
+                    "y": -129.2221393108008,
+                    "ports": [
+                        {
+                            "id": "cfdf0ab8-65e3-4fff-8f3a-5b6dc0b738d6",
+                            "type": "default",
+                            "extras": {},
+                            "x": 2692.3334813874044,
+                            "y": -102.5520010617932,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "c304a0df-a115-4489-8114-73a0c87ae1d0",
+                            "links": [
+                                "c9471436-1c46-401d-b93e-0a73b7d2f7b5"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "de7c5071-6a9c-4cc7-ab50-f52d579ddecb",
+                            "type": "default",
+                            "extras": {},
+                            "x": 2692.3334813874044,
+                            "y": -81.21869332021049,
+                            "name": "parameter-any-msg",
+                            "alignment": "left",
+                            "parentNode": "c304a0df-a115-4489-8114-73a0c87ae1d0",
+                            "links": [
+                                "29577b31-ec84-45d3-8f14-12f54adf514b"
+                            ],
+                            "in": true,
+                            "label": "msg",
+                            "varName": "msg",
+                            "portType": "",
+                            "dataType": "any"
+                        },
+                        {
+                            "id": "a2e5e722-0db4-4c12-8469-5fee0e274ee0",
+                            "type": "default",
+                            "extras": {},
+                            "x": 2765.635444313749,
+                            "y": -102.5520010617932,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "c304a0df-a115-4489-8114-73a0c87ae1d0",
+                            "links": [
+                                "584f34af-e97b-44af-aa0a-0bd8155d42cf"
+                            ],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        }
+                    ],
+                    "name": "Print",
+                    "color": "rgb(255,153,0)",
+                    "portsInOrder": [
+                        "cfdf0ab8-65e3-4fff-8f3a-5b6dc0b738d6",
+                        "de7c5071-6a9c-4cc7-ab50-f52d579ddecb"
+                    ],
+                    "portsOutOrder": [
+                        "a2e5e722-0db4-4c12-8469-5fee0e274ee0"
+                    ]
+                },
+                "de10d6e0-4c20-47ff-89d2-826a210270cc": {
+                    "id": "de10d6e0-4c20-47ff-89d2-826a210270cc",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "library_component",
+                        "path": "xai_components/xai_gradio/gradio_component.py",
+                        "description": "Creates a deep copy of the input data and outputs the copied data.\n\n##### inPorts:\n- data (any): The input data to be deep-copied.\n\n##### outPorts:\n- copied_data (any): The deep-copied output data.",
+                        "lineNo": [
+                            {
+                                "lineno": 96,
+                                "end_lineno": 114
+                            }
+                        ],
+                        "borderColor": "rgb(0,192,255)"
+                    },
+                    "x": 1941.3864642990545,
+                    "y": -171.46347663885388,
+                    "ports": [
+                        {
+                            "id": "6da7a46d-585e-4ea8-933f-e79647d48b02",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1942.052431219173,
+                            "y": -144.7916347910954,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "de10d6e0-4c20-47ff-89d2-826a210270cc",
+                            "links": [
+                                "2c81389b-d70a-487f-93f6-a46829c5cc47"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "20a04b46-243c-4bfd-a2d4-89626b1d565e",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1942.052431219173,
+                            "y": -123.45832704951268,
+                            "name": "parameter-any-data",
+                            "alignment": "left",
+                            "parentNode": "de10d6e0-4c20-47ff-89d2-826a210270cc",
+                            "links": [
+                                "3a0a7cc2-092f-4405-b328-8cb47d38e3d1"
+                            ],
+                            "in": true,
+                            "label": "data",
+                            "varName": "data",
+                            "portType": "",
+                            "dataType": "any"
+                        },
+                        {
+                            "id": "fba13c01-dfad-4795-bf5b-97619742bc70",
+                            "type": "default",
+                            "extras": {},
+                            "x": 2073.750236794932,
+                            "y": -144.7916347910954,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "de10d6e0-4c20-47ff-89d2-826a210270cc",
+                            "links": [
+                                "849545b6-7d2f-4c6a-9a3d-7c9ad30b3ca1"
+                            ],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "dc09050a-5845-4292-b703-e5cbfa7a7903",
+                            "type": "default",
+                            "extras": {},
+                            "x": 2073.750236794932,
+                            "y": -123.45832704951268,
+                            "name": "parameter-out-any-copied_data",
+                            "alignment": "right",
+                            "parentNode": "de10d6e0-4c20-47ff-89d2-826a210270cc",
+                            "links": [
+                                "8b220192-2108-412f-87e3-0bb6c02bed1d"
+                            ],
+                            "in": false,
+                            "label": "copied_data",
+                            "varName": "copied_data",
+                            "portType": "",
+                            "dataType": "any"
+                        }
+                    ],
+                    "name": "DeepCopy",
+                    "color": "rgb(153,204,51)",
+                    "portsInOrder": [
+                        "6da7a46d-585e-4ea8-933f-e79647d48b02",
+                        "20a04b46-243c-4bfd-a2d4-89626b1d565e"
+                    ],
+                    "portsOutOrder": [
+                        "fba13c01-dfad-4795-bf5b-97619742bc70",
+                        "dc09050a-5845-4292-b703-e5cbfa7a7903"
+                    ]
+                },
+                "ccab74ea-a3a9-46b5-8483-d1db1a7ece84": {
+                    "id": "ccab74ea-a3a9-46b5-8483-d1db1a7ece84",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "comment",
+                        "commentInput": "This workflow requires:\n1. XAI AGENT component library\n2. XAI OPENAI component library (and a API key)\n3. an openweather API key"
+                    },
+                    "x": -226.7785747300302,
+                    "y": -159.5432961547997,
+                    "ports": [],
+                    "name": "Comment:",
+                    "color": "rgb(255,255,255)",
+                    "portsInOrder": [],
+                    "portsOutOrder": []
                 }
             }
         }

--- a/examples/GradioChat.xircuits
+++ b/examples/GradioChat.xircuits
@@ -1,12 +1,12 @@
 {
     "id": "cb56846a-ec6c-4db1-a08d-59a025904d3e",
-    "offsetX": 251.45728913385835,
-    "offsetY": 120.28330345127392,
-    "zoom": 76,
+    "offsetX": 56.01828198907071,
+    "offsetY": 129.79094119356677,
+    "zoom": 47.666666666666664,
     "gridSize": 0,
     "layers": [
         {
-            "id": "02c488db-b8bd-40c9-ae4b-16651b7a1297",
+            "id": "fc94c55f-9085-4335-aa80-706d1a624cf6",
             "type": "diagram-links",
             "isSvg": true,
             "transformed": true,
@@ -15,22 +15,22 @@
                     "id": "d6ac3c65-54bf-48d0-abd5-94aee79f157a",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "407eb325-7e80-4f8c-9069-4b197ed8af36",
-                    "sourcePort": "8dc0e3c7-ac65-4283-b7ba-cc6fe49038e8",
-                    "target": "a1446472-fd26-4b3c-9c88-2a09cdd3919d",
-                    "targetPort": "16a717ec-f9b0-4dda-ac08-d24743f7b46e",
+                    "source": "4fb402e8-e3bf-4312-b412-7da0195b037d",
+                    "sourcePort": "bb834ffb-cf0d-419a-9bc6-3e94a54b6d6d",
+                    "target": "1e0206e0-4790-4aee-a4c7-08966461c28d",
+                    "targetPort": "9d274d1b-667f-49b4-b02e-38a7d45e616b",
                     "points": [
                         {
                             "id": "4885da1b-7033-4135-a94c-86cff294d045",
                             "type": "point",
-                            "x": 630.7375193761216,
-                            "y": 115.61250034166261
+                            "x": 630.7188413093704,
+                            "y": 115.34375486910335
                         },
                         {
                             "id": "73fed294-99e8-4dea-a0c8-9bb06715c41e",
                             "type": "point",
-                            "x": 818.9625690976889,
-                            "y": 58.16249696866712
+                            "x": 753.0834883810487,
+                            "y": -103.86454232686478
                         }
                     ],
                     "labels": [],
@@ -43,22 +43,22 @@
                     "id": "fbf0f762-2964-4022-8008-e7ee22bab482",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "a1446472-fd26-4b3c-9c88-2a09cdd3919d",
-                    "sourcePort": "2ff8fb62-8d99-4c77-8d2b-65532cd3d49e",
-                    "target": "64224dac-e636-485d-89b4-c600e4fc0b0a",
-                    "targetPort": "7f6fd333-8d2a-4048-a030-22980d090035",
+                    "source": "1e0206e0-4790-4aee-a4c7-08966461c28d",
+                    "sourcePort": "55bd1948-1aab-45d0-b73b-1132f2b5ee59",
+                    "target": "125b4ea5-15e4-4395-a565-e9fdd5bb5436",
+                    "targetPort": "48cb4669-7694-491f-b5bb-edd864546178",
                     "points": [
                         {
                             "id": "61165e38-3e23-4a38-ac53-d14ef763a5e5",
                             "type": "point",
-                            "x": 941.2749981744357,
-                            "y": 58.16249696866712
+                            "x": 875.6665815574037,
+                            "y": -103.86454232686478
                         },
                         {
                             "id": "5af05fa6-7ab6-424d-8ca2-8c7921a6cb44",
                             "type": "point",
-                            "x": 1125.6875189846132,
-                            "y": 142.31249006205735
+                            "x": 930.3855381379325,
+                            "y": -111.052072204214
                         }
                     ],
                     "labels": [],
@@ -71,22 +71,22 @@
                     "id": "9daf4b70-90db-404a-b2f2-4423bc8b9c51",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "407eb325-7e80-4f8c-9069-4b197ed8af36",
-                    "sourcePort": "96272b46-5f19-469a-84a0-c55cb342448e",
-                    "target": "a1446472-fd26-4b3c-9c88-2a09cdd3919d",
-                    "targetPort": "5eeb0b07-4986-4385-9776-56e4691142db",
+                    "source": "4fb402e8-e3bf-4312-b412-7da0195b037d",
+                    "sourcePort": "82d6080f-56b8-4cb9-9e6f-18bfc57edbc2",
+                    "target": "1e0206e0-4790-4aee-a4c7-08966461c28d",
+                    "targetPort": "8400077f-7073-442c-907b-2fd145a43b29",
                     "points": [
                         {
                             "id": "a78a45e4-8ba6-47c0-a879-e8a1438b4df9",
                             "type": "point",
-                            "x": 630.7375193761216,
-                            "y": 137.21248074616506
+                            "x": 630.7188413093704,
+                            "y": 136.67707852786646
                         },
                         {
                             "id": "f48777eb-bede-42cf-bc4d-7b014b6a9e03",
                             "type": "point",
-                            "x": 818.9625690976889,
-                            "y": 79.76249745052363
+                            "x": 753.0834883810487,
+                            "y": -82.53121866810167
                         }
                     ],
                     "labels": [],
@@ -95,110 +95,26 @@
                     "curvyness": 50,
                     "selectedColor": "rgb(0,192,255)"
                 },
-                "a542d887-a77e-4329-95d4-217f67721f43": {
-                    "id": "a542d887-a77e-4329-95d4-217f67721f43",
-                    "type": "triangle-link",
-                    "selected": false,
-                    "source": "407eb325-7e80-4f8c-9069-4b197ed8af36",
-                    "sourcePort": "0b661232-6435-4f60-a642-b5537894391d",
-                    "target": "f3131bd5-c507-44e7-9cf3-63e9f923f238",
-                    "targetPort": "192a107f-e204-4a9e-899f-e398b9f01ef4",
-                    "points": [
-                        {
-                            "id": "a3172508-eddd-416e-ae13-c44c093562dc",
-                            "type": "point",
-                            "x": 630.7375193761216,
-                            "y": 158.8125013053756
-                        },
-                        {
-                            "id": "0266a988-e87d-4e43-806a-1a32370d0cf9",
-                            "type": "point",
-                            "x": 778.2999842909453,
-                            "y": 234.76252154334847
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "e3ee4b59-aa79-4de5-b74f-037968d8a72e": {
-                    "id": "e3ee4b59-aa79-4de5-b74f-037968d8a72e",
-                    "type": "parameter-link",
-                    "selected": false,
-                    "source": "407eb325-7e80-4f8c-9069-4b197ed8af36",
-                    "sourcePort": "7b68a1aa-bab3-44ac-a964-1b8b8ef553cf",
-                    "target": "f3131bd5-c507-44e7-9cf3-63e9f923f238",
-                    "targetPort": "9541912d-831a-474f-aba1-f6d289339a72",
-                    "points": [
-                        {
-                            "id": "dee7bd46-abb8-47c3-98f8-7bdd99276435",
-                            "type": "point",
-                            "x": 630.7375193761216,
-                            "y": 180.41252186458613
-                        },
-                        {
-                            "id": "583b614b-d40a-4371-ba7a-4485f52cf589",
-                            "type": "point",
-                            "x": 778.2999842909453,
-                            "y": 277.9624823523534
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "1d1f7e4b-27b3-4549-b560-5b29a06365eb": {
-                    "id": "1d1f7e4b-27b3-4549-b560-5b29a06365eb",
-                    "type": "parameter-link",
-                    "selected": false,
-                    "source": "407eb325-7e80-4f8c-9069-4b197ed8af36",
-                    "sourcePort": "0df37b77-b3af-474c-8e4b-bde4a5cc010c",
-                    "target": "f3131bd5-c507-44e7-9cf3-63e9f923f238",
-                    "targetPort": "68d661ca-3c68-46ce-b599-5992802b1b4b",
-                    "points": [
-                        {
-                            "id": "b702ecc8-9ed3-4ba4-b419-3a315b4c9aee",
-                            "type": "point",
-                            "x": 630.7375193761216,
-                            "y": 202.01252673836382
-                        },
-                        {
-                            "id": "7ffd6a0d-0166-49e5-939a-7b388ac6ad62",
-                            "type": "point",
-                            "x": 778.2999842909453,
-                            "y": 299.5625029115639
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "3a27aa4a-b186-4084-ad71-9c5efba1a324": {
-                    "id": "3a27aa4a-b186-4084-ad71-9c5efba1a324",
+                "bd8d2655-88e1-4616-9b09-bc2ecb8a4d2a": {
+                    "id": "bd8d2655-88e1-4616-9b09-bc2ecb8a4d2a",
                     "type": "triangle-link",
                     "selected": false,
                     "source": "5d73cd7a-64b1-4d67-9e50-418d0010ba69",
                     "sourcePort": "5ede8d71-dbc9-4826-b941-11cb9a38a7e7",
-                    "target": "060bdc94-b9bf-4a14-96b4-9f0ce943ac53",
-                    "targetPort": "19fb0d11-0acc-41e5-9fa9-7c1c129fb63e",
+                    "target": "0aba0db7-12f7-403e-8251-50696047142e",
+                    "targetPort": "8db668e0-7aad-4d64-886a-ef2bd9de0ed4",
                     "points": [
                         {
-                            "id": "1fac802a-9346-40e0-8365-f81f1235b547",
+                            "id": "e9611efa-436d-4d4a-9b7b-34e046c3ca9c",
                             "type": "point",
-                            "x": -223.09997760725605,
-                            "y": 112.16251260390658
+                            "x": 144.52081082423055,
+                            "y": 59.87502621006706
                         },
                         {
-                            "id": "08535cb0-7c28-40b5-9579-ba68eafb3b4c",
+                            "id": "bff1a261-2147-48b5-b6b6-b1998e5626cc",
                             "type": "point",
-                            "x": -97.56250683988353,
-                            "y": 114.0999929531963
+                            "x": 238.21876021370826,
+                            "y": 111.89588709547378
                         }
                     ],
                     "labels": [],
@@ -207,82 +123,26 @@
                     "curvyness": 50,
                     "selectedColor": "rgb(0,192,255)"
                 },
-                "74d50325-134b-499b-964d-59d17a326413": {
-                    "id": "74d50325-134b-499b-964d-59d17a326413",
-                    "type": "triangle-link",
-                    "selected": false,
-                    "source": "060bdc94-b9bf-4a14-96b4-9f0ce943ac53",
-                    "sourcePort": "7fb557cc-98dc-4e56-921e-abbea92a12b0",
-                    "target": "28fa981b-4925-48ea-a8d4-4d894b58b6f0",
-                    "targetPort": "b3dbaabd-a248-414d-be3d-9723a1b24011",
-                    "points": [
-                        {
-                            "id": "b0971ebf-3f89-4d8a-8c23-1630986ae522",
-                            "type": "point",
-                            "x": 40.62502207150628,
-                            "y": 114.0999929531963
-                        },
-                        {
-                            "id": "7665ead9-6bda-46f2-b357-a8e87c6c1339",
-                            "type": "point",
-                            "x": 221.86254211372494,
-                            "y": 115.95000066290027
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "e2b073c1-e83b-4d2e-bff8-14c9b3cb1ede": {
-                    "id": "e2b073c1-e83b-4d2e-bff8-14c9b3cb1ede",
-                    "type": "triangle-link",
-                    "selected": false,
-                    "source": "28fa981b-4925-48ea-a8d4-4d894b58b6f0",
-                    "sourcePort": "e165cfb4-312f-47ae-898c-8fbb0c34b695",
-                    "target": "407eb325-7e80-4f8c-9069-4b197ed8af36",
-                    "targetPort": "95d5892a-07a2-4a6b-b32e-ebf569a0e74e",
-                    "points": [
-                        {
-                            "id": "367fc955-af5e-4449-8e61-56affc158876",
-                            "type": "point",
-                            "x": 364.32502155451436,
-                            "y": 115.95000066290027
-                        },
-                        {
-                            "id": "a540102c-a8d9-488d-9d7a-969d304f1986",
-                            "type": "point",
-                            "x": 475.6625427562003,
-                            "y": 115.61250034166261
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "a48b5fae-83bf-47fa-b422-d4ea40ff467e": {
-                    "id": "a48b5fae-83bf-47fa-b422-d4ea40ff467e",
+                "c4555c5f-6b89-464a-b61c-f1903c5d54cd": {
+                    "id": "c4555c5f-6b89-464a-b61c-f1903c5d54cd",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "e61069e0-b824-4b9a-ac6a-636875bc6058",
-                    "sourcePort": "fd846aff-01e9-4f2d-8dbf-a6a919ef4334",
-                    "target": "28fa981b-4925-48ea-a8d4-4d894b58b6f0",
-                    "targetPort": "4a9a0f9e-5192-435c-b49c-48f0340c69b1",
+                    "source": "0d8d7ca1-736c-4509-9236-9fc021d89a90",
+                    "sourcePort": "4eb83e1c-78f9-44aa-a173-4961ad1564be",
+                    "target": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                    "targetPort": "43963c28-83be-4d6e-8736-9ca3ef8dca5c",
                     "points": [
                         {
-                            "id": "2625b8ad-2284-4261-80e3-c19495e740d5",
+                            "id": "ea1c4c4d-bb40-47b9-bfe4-c9469d149c37",
                             "type": "point",
-                            "x": 179.82501179190103,
-                            "y": 319.1624977717613
+                            "x": 758.4124654081938,
+                            "y": 477.1374737592459
                         },
                         {
-                            "id": "9a54997a-dbb7-45f3-8522-86df5248deaf",
+                            "id": "c714b093-a720-41b8-a228-ffe34a5e9f3c",
                             "type": "point",
-                            "x": 221.86254211372494,
-                            "y": 137.5500212221108
+                            "x": 1039.218691068986,
+                            "y": 125.37505352650064
                         }
                     ],
                     "labels": [],
@@ -291,26 +151,334 @@
                     "curvyness": 50,
                     "selectedColor": "rgb(0,192,255)"
                 },
-                "f3a69f37-e68a-4033-bc0b-ed02bbcfa690": {
-                    "id": "f3a69f37-e68a-4033-bc0b-ed02bbcfa690",
+                "8c2fc724-37a7-4710-92fd-0e8c6a94a3da": {
+                    "id": "8c2fc724-37a7-4710-92fd-0e8c6a94a3da",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "0a824373-6b7d-4a8c-a157-e5bd78d298c5",
-                    "sourcePort": "f83fae1e-311b-4053-89fa-a7f51df0ca93",
-                    "target": "f3131bd5-c507-44e7-9cf3-63e9f923f238",
-                    "targetPort": "f2cc6f99-1a94-4369-8a65-4e3ce2bcd354",
+                    "source": "4fb402e8-e3bf-4312-b412-7da0195b037d",
+                    "sourcePort": "c70f5f3d-2722-414b-bce9-5a096ebab57f",
+                    "target": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                    "targetPort": "b4a12b56-948f-47cb-98d8-1034a86acc4c",
                     "points": [
                         {
-                            "id": "acdea176-2942-45a2-8800-c4f36dc8f61d",
+                            "id": "298cbff3-82d2-42d6-958b-c32a3c9a310b",
                             "type": "point",
-                            "x": 635.6500626729355,
-                            "y": 395.7249977717613
+                            "x": 630.7188413093704,
+                            "y": 179.3437258453927
                         },
                         {
-                            "id": "98d49dbd-ffe2-40aa-beba-1a407d338a6f",
+                            "id": "a628bb88-c415-45d5-acb5-b77df2107479",
                             "type": "point",
-                            "x": 778.2999842909453,
-                            "y": 321.1625153143494
+                            "x": 1039.3854066775962,
+                            "y": 166.04168974672572
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "9ab34629-0c2f-4e2e-9851-0a92ed710654": {
+                    "id": "9ab34629-0c2f-4e2e-9851-0a92ed710654",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "6f29bfeb-4597-4402-a8a1-8a3f6a30bfcf",
+                    "sourcePort": "5852b1fd-f568-4557-9f1c-3ed061b6f340",
+                    "target": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                    "targetPort": "57cc41f4-83ca-4f01-9d1a-a7fccaf1f23d",
+                    "points": [
+                        {
+                            "id": "71743c59-f0f9-41e6-8cb1-75aed9cd8438",
+                            "type": "point",
+                            "x": 993.3958153623466,
+                            "y": 24.635435654703798
+                        },
+                        {
+                            "id": "4480ca74-cb1b-456a-afe6-a15f539dbacb",
+                            "type": "point",
+                            "x": 1039.218691068986,
+                            "y": 145.37505746124083
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "be1591d8-442d-48ae-8a26-86886a4652c8": {
+                    "id": "be1591d8-442d-48ae-8a26-86886a4652c8",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "0aba0db7-12f7-403e-8251-50696047142e",
+                    "sourcePort": "fb2c4637-e1e4-42e4-91af-16919a60d760",
+                    "target": "4fb402e8-e3bf-4312-b412-7da0195b037d",
+                    "targetPort": "d439e6b2-474e-4d7d-9afb-f661fd7ff5f9",
+                    "points": [
+                        {
+                            "id": "682552b4-09e2-4839-9c69-48c713588712",
+                            "type": "point",
+                            "x": 376.677033507797,
+                            "y": 111.89588709547378
+                        },
+                        {
+                            "id": "e9443032-8534-49f3-b83e-522ae8a15125",
+                            "type": "point",
+                            "x": 475.39585009160385,
+                            "y": 115.34375486910335
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "67fe2867-8b94-4f28-981c-d30155ea8f3d": {
+                    "id": "67fe2867-8b94-4f28-981c-d30155ea8f3d",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "b2e4e0c4-fefd-4091-9d51-800b8726cfde",
+                    "sourcePort": "b572a446-ba8a-433b-a963-4241bb16b00f",
+                    "target": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                    "targetPort": "f5e628bb-b13f-4e1f-afaa-6f1227660fe8",
+                    "points": [
+                        {
+                            "id": "4d0b7272-d2c1-47c6-b5f3-769b27dce327",
+                            "type": "point",
+                            "x": 950.4166361902708,
+                            "y": 106.31255779469336
+                        },
+                        {
+                            "id": "9c8942c7-5e66-404f-a6df-90c8225597e2",
+                            "type": "point",
+                            "x": 1039.3854066775962,
+                            "y": 104.7083362106134
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "1f456ffd-259d-4e42-9f88-f63e9707d8ff": {
+                    "id": "1f456ffd-259d-4e42-9f88-f63e9707d8ff",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "4fb402e8-e3bf-4312-b412-7da0195b037d",
+                    "sourcePort": "67b55f4f-b434-4fde-a395-6cef50e74267",
+                    "target": "b2e4e0c4-fefd-4091-9d51-800b8726cfde",
+                    "targetPort": "f5affac9-e009-40c5-8441-0ff686e3b644",
+                    "points": [
+                        {
+                            "id": "4d0ccba5-d515-4855-99eb-ccd0bac13226",
+                            "type": "point",
+                            "x": 630.7188413093704,
+                            "y": 200.67711352704697
+                        },
+                        {
+                            "id": "ca0a94b2-2365-42fa-81aa-762dc60202d2",
+                            "type": "point",
+                            "x": 818.7187320436361,
+                            "y": 127.6458814534565
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "b6c7b093-7041-45f5-818c-adb1bf566b97": {
+                    "id": "b6c7b093-7041-45f5-818c-adb1bf566b97",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "b2e4e0c4-fefd-4091-9d51-800b8726cfde",
+                    "sourcePort": "e705d21e-54c5-4b7d-b158-a97832f963c7",
+                    "target": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                    "targetPort": "b49eb610-a088-4abb-82bb-e03e4c5d4007",
+                    "points": [
+                        {
+                            "id": "8823c336-6b3a-4d15-9bc4-f8dba6a197ea",
+                            "type": "point",
+                            "x": 950.4166361902708,
+                            "y": 127.6458814534565
+                        },
+                        {
+                            "id": "a5edf9a3-243f-4907-89b2-ab428697f9f5",
+                            "type": "point",
+                            "x": 1039.3854066775962,
+                            "y": 187.37501340548883
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "d7dc6c89-4494-4b81-9376-c53967c23d29": {
+                    "id": "d7dc6c89-4494-4b81-9376-c53967c23d29",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "4fb402e8-e3bf-4312-b412-7da0195b037d",
+                    "sourcePort": "3a112b80-b4e2-4632-9759-abe35db3e81c",
+                    "target": "b2e4e0c4-fefd-4091-9d51-800b8726cfde",
+                    "targetPort": "716e950b-c151-4d87-b942-fa3bca9d4c42",
+                    "points": [
+                        {
+                            "id": "84dd27cf-8e24-45f6-b01a-04e11bcc950b",
+                            "type": "point",
+                            "x": 630.7188413093704,
+                            "y": 158.01046620952076
+                        },
+                        {
+                            "id": "f2076b22-75a7-4af7-bf09-56c910761550",
+                            "type": "point",
+                            "x": 818.7187320436361,
+                            "y": 106.31255779469336
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "bd735439-03b2-4e7b-9d35-3977a144c90b": {
+                    "id": "bd735439-03b2-4e7b-9d35-3977a144c90b",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                    "sourcePort": "dc9c3085-abb7-4add-9e3f-038b5c850d66",
+                    "target": "874c9d4b-4871-41d2-ad42-079fb6f21b9e",
+                    "targetPort": "516bbda0-e001-4659-a525-fd93f602051a",
+                    "points": [
+                        {
+                            "id": "8021f627-f824-49ba-bee0-b6e86cff2a2d",
+                            "type": "point",
+                            "x": 1337.0416566775962,
+                            "y": 104.7083362106134
+                        },
+                        {
+                            "id": "ed131b41-5143-4c3d-89c5-92551c3af304",
+                            "type": "point",
+                            "x": 1512.8541498484879,
+                            "y": 402.84373352813964
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "22d03bd8-4ae2-4650-a659-be042d6d2ee7": {
+                    "id": "22d03bd8-4ae2-4650-a659-be042d6d2ee7",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                    "sourcePort": "57cfe194-a785-4bfa-bdfc-7de5ec46ce63",
+                    "target": "874c9d4b-4871-41d2-ad42-079fb6f21b9e",
+                    "targetPort": "14fd66f6-d2f8-4b42-bda4-96832579299b",
+                    "points": [
+                        {
+                            "id": "25dbf6a3-cdb8-4cfa-aa7c-931bae0e5c92",
+                            "type": "point",
+                            "x": 1337.0416566775962,
+                            "y": 126.04172389226767
+                        },
+                        {
+                            "id": "4b6a31ef-b4b7-4583-a92e-ac33119ff5cf",
+                            "type": "point",
+                            "x": 1512.8541498484879,
+                            "y": 466.8437685273202
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "8f64a4db-def3-44b3-9327-99bfa74b6388": {
+                    "id": "8f64a4db-def3-44b3-9327-99bfa74b6388",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "4fb402e8-e3bf-4312-b412-7da0195b037d",
+                    "sourcePort": "67b55f4f-b434-4fde-a395-6cef50e74267",
+                    "target": "874c9d4b-4871-41d2-ad42-079fb6f21b9e",
+                    "targetPort": "1bc9391d-85d7-4a06-9d00-ab32f388e8ef",
+                    "points": [
+                        {
+                            "id": "caffc310-8948-4fc0-acae-67a6921bbe9f",
+                            "type": "point",
+                            "x": 630.7188413093704,
+                            "y": 200.67711352704697
+                        },
+                        {
+                            "id": "e7a1a4d1-1fd1-425e-a5f7-fcbe60df1c3c",
+                            "type": "point",
+                            "x": 1512.8541498484879,
+                            "y": 445.5104448685571
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "a9ef593a-9fe5-4969-a1bc-f8aa98160107": {
+                    "id": "a9ef593a-9fe5-4969-a1bc-f8aa98160107",
+                    "type": "parameter-link",
+                    "selected": false,
+                    "source": "4fb402e8-e3bf-4312-b412-7da0195b037d",
+                    "sourcePort": "c70f5f3d-2722-414b-bce9-5a096ebab57f",
+                    "target": "874c9d4b-4871-41d2-ad42-079fb6f21b9e",
+                    "targetPort": "846cbcfb-08de-4325-9dd0-a49ff16143c0",
+                    "points": [
+                        {
+                            "id": "98f8dfe5-516a-42fb-951e-122d336cf56d",
+                            "type": "point",
+                            "x": 630.7188413093704,
+                            "y": 179.3437258453927
+                        },
+                        {
+                            "id": "fff48658-528f-4de8-b94e-a298201efcad",
+                            "type": "point",
+                            "x": 1512.8541498484879,
+                            "y": 424.1771212097939
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "bf227e13-dced-42b2-bbe4-2dca4bd1a797": {
+                    "id": "bf227e13-dced-42b2-bbe4-2dca4bd1a797",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "0c538b40-8c7f-4b25-9e78-4547d1a9dfbf",
+                    "sourcePort": "83dfd1a2-c1ac-4b4d-bce6-7135867e657c",
+                    "target": "0aba0db7-12f7-403e-8251-50696047142e",
+                    "targetPort": "1a06879d-c366-4bd6-98dd-3e178dc84d59",
+                    "points": [
+                        {
+                            "id": "5768b902-2658-43e0-9e88-7e223f674732",
+                            "type": "point",
+                            "x": 141.8541293611624,
+                            "y": 286.06245877262177
+                        },
+                        {
+                            "id": "ea64c5cd-f54e-450a-8a80-1ea34c322a1f",
+                            "type": "point",
+                            "x": 238.21876021370826,
+                            "y": 175.89583706425196
                         }
                     ],
                     "labels": [],
@@ -322,7 +490,7 @@
             }
         },
         {
-            "id": "086b648e-5bf1-410b-8cda-07e4b0a6be1b",
+            "id": "dd99324c-9ab7-4138-870a-936511316713",
             "type": "diagram-nodes",
             "isSvg": false,
             "transformed": true,
@@ -335,20 +503,20 @@
                         "type": "Start",
                         "borderColor": "rgb(0,192,255)"
                     },
-                    "x": -290.85185185185185,
-                    "y": 75.07407407407408,
+                    "x": 76.77820595161644,
+                    "y": 23.050952686790833,
                     "ports": [
                         {
                             "id": "5ede8d71-dbc9-4826-b941-11cb9a38a7e7",
                             "type": "default",
                             "extras": {},
-                            "x": -233.40002161681608,
-                            "y": 101.86252443448744,
+                            "x": 134.35414576702823,
+                            "y": 49.70836115286474,
                             "name": "out-0",
                             "alignment": "right",
                             "parentNode": "5d73cd7a-64b1-4d67-9e50-418d0010ba69",
                             "links": [
-                                "3a27aa4a-b186-4084-ad71-9c5efba1a324"
+                                "bd8d2655-88e1-4616-9b09-bc2ecb8a4d2a"
                             ],
                             "in": false,
                             "label": "▶",
@@ -364,220 +532,25 @@
                         "5ede8d71-dbc9-4826-b941-11cb9a38a7e7"
                     ]
                 },
-                "f3131bd5-c507-44e7-9cf3-63e9f923f238": {
-                    "id": "f3131bd5-c507-44e7-9cf3-63e9f923f238",
-                    "type": "custom-node",
-                    "selected": false,
-                    "extras": {
-                        "type": "library_component",
-                        "path": "xai_components/xai_gradio/gradio_component.py",
-                        "description": "Collects return values for a Gradio function, integrates predefined responses from ctx,\nOpenAI, Agent, and appends chat history with timestamps.\n\n##### inPorts:\n- results (list[any]): Results for the Gradio function.\n- message (str): The user message to process.\n- history (list): Chat history to update and save (optional).\n- use_responses (bool): Whether to use predefined responses from ctx.\n- use_openai (bool): Whether to use OpenAI for generating responses.\n- use_agent (bool): Whether to use Agent for generating responses.\n- log_file (str): Path to the file where the conversation history will be saved (optional).",
-                        "lineNo": [
-                            {
-                                "lineno": 113,
-                                "end_lineno": 224
-                            }
-                        ],
-                        "sourceBranchId": "407eb325-7e80-4f8c-9069-4b197ed8af36",
-                        "portId": "0b661232-6435-4f60-a642-b5537894391d",
-                        "nextNode": "None"
-                    },
-                    "x": 767.1999816894532,
-                    "y": 197.66666666666663,
-                    "ports": [
-                        {
-                            "id": "192a107f-e204-4a9e-899f-e398b9f01ef4",
-                            "type": "default",
-                            "extras": {},
-                            "x": 768.0000927437925,
-                            "y": 224.4625176884965,
-                            "name": "in-0",
-                            "alignment": "left",
-                            "parentNode": "f3131bd5-c507-44e7-9cf3-63e9f923f238",
-                            "links": [
-                                "a542d887-a77e-4329-95d4-217f67721f43"
-                            ],
-                            "in": true,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        },
-                        {
-                            "id": "806d7d32-90f3-4298-900d-dc85681b55a7",
-                            "type": "default",
-                            "extras": {},
-                            "x": 768.0000927437925,
-                            "y": 246.06249809299894,
-                            "name": "parameter-dynalist-results",
-                            "alignment": "left",
-                            "parentNode": "f3131bd5-c507-44e7-9cf3-63e9f923f238",
-                            "links": [],
-                            "in": true,
-                            "label": "results",
-                            "varName": "results",
-                            "portType": "",
-                            "dataType": "dynalist",
-                            "dynaPortOrder": 0,
-                            "dynaPortRef": {
-                                "previous": null,
-                                "next": null
-                            }
-                        },
-                        {
-                            "id": "9541912d-831a-474f-aba1-f6d289339a72",
-                            "type": "default",
-                            "extras": {},
-                            "x": 768.0000927437925,
-                            "y": 267.6624784975014,
-                            "name": "parameter-string-message",
-                            "alignment": "left",
-                            "parentNode": "f3131bd5-c507-44e7-9cf3-63e9f923f238",
-                            "links": [
-                                "e3ee4b59-aa79-4de5-b74f-037968d8a72e"
-                            ],
-                            "in": true,
-                            "label": "message",
-                            "varName": "message",
-                            "portType": "",
-                            "dataType": "string"
-                        },
-                        {
-                            "id": "68d661ca-3c68-46ce-b599-5992802b1b4b",
-                            "type": "default",
-                            "extras": {},
-                            "x": 768.0000927437925,
-                            "y": 289.26249905671193,
-                            "name": "parameter-list-history",
-                            "alignment": "left",
-                            "parentNode": "f3131bd5-c507-44e7-9cf3-63e9f923f238",
-                            "links": [
-                                "1d1f7e4b-27b3-4549-b560-5b29a06365eb"
-                            ],
-                            "in": true,
-                            "label": "history",
-                            "varName": "history",
-                            "portType": "",
-                            "dataType": "list"
-                        },
-                        {
-                            "id": "f2cc6f99-1a94-4369-8a65-4e3ce2bcd354",
-                            "type": "default",
-                            "extras": {},
-                            "x": 768.0000927437925,
-                            "y": 310.86247946121443,
-                            "name": "parameter-boolean-use_responses",
-                            "alignment": "left",
-                            "parentNode": "f3131bd5-c507-44e7-9cf3-63e9f923f238",
-                            "links": [
-                                "f3a69f37-e68a-4033-bc0b-ed02bbcfa690"
-                            ],
-                            "in": true,
-                            "label": "use_responses",
-                            "varName": "use_responses",
-                            "portType": "",
-                            "dataType": "boolean"
-                        },
-                        {
-                            "id": "23857570-1531-494e-a44d-89cf408ea7be",
-                            "type": "default",
-                            "extras": {},
-                            "x": 768.0000927437925,
-                            "y": 332.46250002042495,
-                            "name": "parameter-boolean-use_openai",
-                            "alignment": "left",
-                            "parentNode": "f3131bd5-c507-44e7-9cf3-63e9f923f238",
-                            "links": [],
-                            "in": true,
-                            "label": "use_openai",
-                            "varName": "use_openai",
-                            "portType": "",
-                            "dataType": "boolean"
-                        },
-                        {
-                            "id": "658d1d98-1bc8-4ec1-95f6-b0f042c19b27",
-                            "type": "default",
-                            "extras": {},
-                            "x": 768.0000927437925,
-                            "y": 354.0625205796355,
-                            "name": "parameter-boolean-use_agent",
-                            "alignment": "left",
-                            "parentNode": "f3131bd5-c507-44e7-9cf3-63e9f923f238",
-                            "links": [],
-                            "in": true,
-                            "label": "use_agent",
-                            "varName": "use_agent",
-                            "portType": "",
-                            "dataType": "boolean"
-                        },
-                        {
-                            "id": "e8b2bf70-de35-4b32-bf23-3cfc6a764e1a",
-                            "type": "default",
-                            "extras": {},
-                            "x": 768.0000927437925,
-                            "y": 375.662541138846,
-                            "name": "parameter-string-log_file",
-                            "alignment": "left",
-                            "parentNode": "f3131bd5-c507-44e7-9cf3-63e9f923f238",
-                            "links": [],
-                            "in": true,
-                            "label": "log_file",
-                            "varName": "log_file",
-                            "portType": "",
-                            "dataType": "string"
-                        },
-                        {
-                            "id": "b58a8ab1-110a-417f-92d3-6ec7fdf259cf",
-                            "type": "default",
-                            "extras": {},
-                            "x": 900.8876017384471,
-                            "y": 224.4625176884965,
-                            "name": "out-0",
-                            "alignment": "right",
-                            "parentNode": "f3131bd5-c507-44e7-9cf3-63e9f923f238",
-                            "links": [],
-                            "in": false,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        }
-                    ],
-                    "name": "GradioFnReturn",
-                    "color": "purple",
-                    "portsInOrder": [
-                        "192a107f-e204-4a9e-899f-e398b9f01ef4",
-                        "806d7d32-90f3-4298-900d-dc85681b55a7",
-                        "9541912d-831a-474f-aba1-f6d289339a72",
-                        "68d661ca-3c68-46ce-b599-5992802b1b4b",
-                        "f2cc6f99-1a94-4369-8a65-4e3ce2bcd354",
-                        "23857570-1531-494e-a44d-89cf408ea7be",
-                        "658d1d98-1bc8-4ec1-95f6-b0f042c19b27",
-                        "e8b2bf70-de35-4b32-bf23-3cfc6a764e1a"
-                    ],
-                    "portsOutOrder": [
-                        "b58a8ab1-110a-417f-92d3-6ec7fdf259cf"
-                    ]
-                },
-                "64224dac-e636-485d-89b4-c600e4fc0b0a": {
-                    "id": "64224dac-e636-485d-89b4-c600e4fc0b0a",
+                "125b4ea5-15e4-4395-a565-e9fdd5bb5436": {
+                    "id": "125b4ea5-15e4-4395-a565-e9fdd5bb5436",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
                         "type": "Finish"
                     },
-                    "x": 1114.5925925925926,
-                    "y": 105.22222222222223,
+                    "x": 919.559127426788,
+                    "y": -147.88851705371326,
                     "ports": [
                         {
-                            "id": "7f6fd333-8d2a-4048-a030-22980d090035",
+                            "id": "48cb4669-7694-491f-b5bb-edd864546178",
                             "type": "default",
                             "extras": {},
-                            "x": 1115.3876274374602,
-                            "y": 132.01248620720537,
+                            "x": 920.2188730807302,
+                            "y": -121.21873726141631,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "64224dac-e636-485d-89b4-c600e4fc0b0a",
+                            "parentNode": "125b4ea5-15e4-4395-a565-e9fdd5bb5436",
                             "links": [
                                 "fbf0f762-2964-4022-8008-e7ee22bab482"
                             ],
@@ -588,14 +561,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "69febf13-f81c-4b80-828c-ef21a2a93e0a",
+                            "id": "d6aaa00f-5a74-4dee-bc53-1691e4aaa710",
                             "type": "default",
                             "extras": {},
-                            "x": 1115.3876274374602,
-                            "y": 153.6125067664159,
+                            "x": 920.2188730807302,
+                            "y": -99.88541360265319,
                             "name": "parameter-dynalist-outputs",
                             "alignment": "left",
-                            "parentNode": "64224dac-e636-485d-89b4-c600e4fc0b0a",
+                            "parentNode": "125b4ea5-15e4-4395-a565-e9fdd5bb5436",
                             "links": [],
                             "in": true,
                             "label": "outputs",
@@ -612,42 +585,40 @@
                     "name": "Finish",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [
-                        "7f6fd333-8d2a-4048-a030-22980d090035",
-                        "69febf13-f81c-4b80-828c-ef21a2a93e0a"
+                        "48cb4669-7694-491f-b5bb-edd864546178",
+                        "d6aaa00f-5a74-4dee-bc53-1691e4aaa710"
                     ],
                     "portsOutOrder": []
                 },
-                "407eb325-7e80-4f8c-9069-4b197ed8af36": {
-                    "id": "407eb325-7e80-4f8c-9069-4b197ed8af36",
+                "4fb402e8-e3bf-4312-b412-7da0195b037d": {
+                    "id": "4fb402e8-e3bf-4312-b412-7da0195b037d",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
-                        "type": "library_component",
+                        "type": "branch",
                         "path": "xai_components/xai_gradio/gradio_component.py",
-                        "description": "Creates a Chatbot interface with support for text and image uploads.",
+                        "description": "Creates a Gradio Chatbot interface.\n\n##### outPorts:\n- interface (gr.Blocks): Gradio Blocks object for the chatbot interface. Connect to `GradioLaunch`.\n- message (str): the most recent user message.\n- history (list): Chat history for the session in OpenAi conversation format.\n\n##### Branches:\n- fn (BaseComponent): Subgraph executor for processing messages.",
                         "lineNo": [
                             {
-                                "lineno": 10,
-                                "end_lineno": 49
+                                "lineno": 7,
+                                "end_lineno": 93
                             }
-                        ],
-                        "finishNodeId": "a1446472-fd26-4b3c-9c88-2a09cdd3919d",
-                        "isBranchNode": true
+                        ]
                     },
                     "x": 464.57035205982345,
                     "y": 78.51851851851853,
                     "ports": [
                         {
-                            "id": "95d5892a-07a2-4a6b-b32e-ebf569a0e74e",
+                            "id": "d439e6b2-474e-4d7d-9afb-f661fd7ff5f9",
                             "type": "default",
                             "extras": {},
-                            "x": 465.36249059021515,
-                            "y": 105.31249648681063,
+                            "x": 465.2291850344015,
+                            "y": 105.17708981190103,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "407eb325-7e80-4f8c-9069-4b197ed8af36",
+                            "parentNode": "4fb402e8-e3bf-4312-b412-7da0195b037d",
                             "links": [
-                                "e2b073c1-e83b-4d2e-bff8-14c9b3cb1ede"
+                                "be1591d8-442d-48ae-8a26-86886a4652c8"
                             ],
                             "in": true,
                             "label": "▶",
@@ -656,14 +627,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "8dc0e3c7-ac65-4283-b7ba-cc6fe49038e8",
+                            "id": "bb834ffb-cf0d-419a-9bc6-3e94a54b6d6d",
                             "type": "default",
                             "extras": {},
-                            "x": 620.4374835229866,
-                            "y": 105.31249648681063,
+                            "x": 620.5521762521681,
+                            "y": 105.17708981190103,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "407eb325-7e80-4f8c-9069-4b197ed8af36",
+                            "parentNode": "4fb402e8-e3bf-4312-b412-7da0195b037d",
                             "links": [
                                 "d6ac3c65-54bf-48d0-abd5-94aee79f157a"
                             ],
@@ -674,14 +645,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "96272b46-5f19-469a-84a0-c55cb342448e",
+                            "id": "82d6080f-56b8-4cb9-9e6f-18bfc57edbc2",
                             "type": "default",
                             "extras": {},
-                            "x": 620.4374835229866,
-                            "y": 126.91247689131309,
+                            "x": 620.5521762521681,
+                            "y": 126.51041347066413,
                             "name": "parameter-out-gr.Blocks-interface",
                             "alignment": "right",
-                            "parentNode": "407eb325-7e80-4f8c-9069-4b197ed8af36",
+                            "parentNode": "4fb402e8-e3bf-4312-b412-7da0195b037d",
                             "links": [
                                 "9daf4b70-90db-404a-b2f2-4423bc8b9c51"
                             ],
@@ -692,16 +663,16 @@
                             "dataType": "gr.Blocks"
                         },
                         {
-                            "id": "0b661232-6435-4f60-a642-b5537894391d",
+                            "id": "3a112b80-b4e2-4632-9759-abe35db3e81c",
                             "type": "default",
                             "extras": {},
-                            "x": 620.4374835229866,
-                            "y": 148.51249745052363,
+                            "x": 620.5521762521681,
+                            "y": 147.84380115231843,
                             "name": "out-flow-fn",
                             "alignment": "right",
-                            "parentNode": "407eb325-7e80-4f8c-9069-4b197ed8af36",
+                            "parentNode": "4fb402e8-e3bf-4312-b412-7da0195b037d",
                             "links": [
-                                "a542d887-a77e-4329-95d4-217f67721f43"
+                                "d7dc6c89-4494-4b81-9376-c53967c23d29"
                             ],
                             "in": false,
                             "label": "fn ▶",
@@ -710,16 +681,17 @@
                             "dataType": ""
                         },
                         {
-                            "id": "7b68a1aa-bab3-44ac-a964-1b8b8ef553cf",
+                            "id": "c70f5f3d-2722-414b-bce9-5a096ebab57f",
                             "type": "default",
                             "extras": {},
-                            "x": 620.4374835229866,
-                            "y": 170.11251800973415,
+                            "x": 620.5521762521681,
+                            "y": 169.17706078819037,
                             "name": "parameter-out-string-message",
                             "alignment": "right",
-                            "parentNode": "407eb325-7e80-4f8c-9069-4b197ed8af36",
+                            "parentNode": "4fb402e8-e3bf-4312-b412-7da0195b037d",
                             "links": [
-                                "e3ee4b59-aa79-4de5-b74f-037968d8a72e"
+                                "8c2fc724-37a7-4710-92fd-0e8c6a94a3da",
+                                "a9ef593a-9fe5-4969-a1bc-f8aa98160107"
                             ],
                             "in": false,
                             "label": "message",
@@ -728,82 +700,65 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "0df37b77-b3af-474c-8e4b-bde4a5cc010c",
+                            "id": "67b55f4f-b434-4fde-a395-6cef50e74267",
                             "type": "default",
                             "extras": {},
-                            "x": 620.4374835229866,
-                            "y": 191.71253856894467,
+                            "x": 620.5521762521681,
+                            "y": 190.51044846984465,
                             "name": "parameter-out-list-history",
                             "alignment": "right",
-                            "parentNode": "407eb325-7e80-4f8c-9069-4b197ed8af36",
+                            "parentNode": "4fb402e8-e3bf-4312-b412-7da0195b037d",
                             "links": [
-                                "1d1f7e4b-27b3-4549-b560-5b29a06365eb"
+                                "1f456ffd-259d-4e42-9f88-f63e9707d8ff",
+                                "8f64a4db-def3-44b3-9327-99bfa74b6388"
                             ],
                             "in": false,
                             "label": "history",
                             "varName": "history",
                             "portType": "",
                             "dataType": "list"
-                        },
-                        {
-                            "id": "dbbf9471-f3e3-4124-8ccf-ce8f672d3861",
-                            "type": "default",
-                            "extras": {},
-                            "x": 620.4374835229866,
-                            "y": 213.31247881873907,
-                            "name": "parameter-out-any-uploaded_image",
-                            "alignment": "right",
-                            "parentNode": "407eb325-7e80-4f8c-9069-4b197ed8af36",
-                            "links": [],
-                            "in": false,
-                            "label": "uploaded_image",
-                            "varName": "uploaded_image",
-                            "portType": "",
-                            "dataType": "any"
                         }
                     ],
                     "name": "GradioChatInterface",
                     "color": "blue",
                     "portsInOrder": [
-                        "95d5892a-07a2-4a6b-b32e-ebf569a0e74e"
+                        "d439e6b2-474e-4d7d-9afb-f661fd7ff5f9"
                     ],
                     "portsOutOrder": [
-                        "8dc0e3c7-ac65-4283-b7ba-cc6fe49038e8",
-                        "96272b46-5f19-469a-84a0-c55cb342448e",
-                        "0b661232-6435-4f60-a642-b5537894391d",
-                        "7b68a1aa-bab3-44ac-a964-1b8b8ef553cf",
-                        "0df37b77-b3af-474c-8e4b-bde4a5cc010c",
-                        "dbbf9471-f3e3-4124-8ccf-ce8f672d3861"
+                        "bb834ffb-cf0d-419a-9bc6-3e94a54b6d6d",
+                        "82d6080f-56b8-4cb9-9e6f-18bfc57edbc2",
+                        "3a112b80-b4e2-4632-9759-abe35db3e81c",
+                        "c70f5f3d-2722-414b-bce9-5a096ebab57f",
+                        "67b55f4f-b434-4fde-a395-6cef50e74267"
                     ]
                 },
-                "a1446472-fd26-4b3c-9c88-2a09cdd3919d": {
-                    "id": "a1446472-fd26-4b3c-9c88-2a09cdd3919d",
+                "1e0206e0-4790-4aee-a4c7-08966461c28d": {
+                    "id": "1e0206e0-4790-4aee-a4c7-08966461c28d",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
                         "type": "library_component",
                         "path": "xai_components/xai_gradio/gradio_component.py",
-                        "description": "Launches a Gradio Interface or Block\n\n##### inPorts:\n- app (Interface | Block): interface or block to launch",
+                        "description": "Launches a Gradio Interface or Block.\n\n##### inPorts:\n- app (Interface | Block): Gradio Interface or Block to launch.",
                         "lineNo": [
                             {
-                                "lineno": 101,
-                                "end_lineno": 110
+                                "lineno": 183,
+                                "end_lineno": 192
                             }
-                        ],
-                        "nextNode": "None"
+                        ]
                     },
-                    "x": 807.8666483561199,
-                    "y": 21.074074074074076,
+                    "x": 742.2521062204339,
+                    "y": -140.69957971357422,
                     "ports": [
                         {
-                            "id": "16a717ec-f9b0-4dda-ac08-d24743f7b46e",
+                            "id": "9d274d1b-667f-49b4-b02e-38a7d45e616b",
                             "type": "default",
                             "extras": {},
-                            "x": 808.6625169317036,
-                            "y": 47.86249311381515,
+                            "x": 742.9168233238464,
+                            "y": -114.03120738406709,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "a1446472-fd26-4b3c-9c88-2a09cdd3919d",
+                            "parentNode": "1e0206e0-4790-4aee-a4c7-08966461c28d",
                             "links": [
                                 "d6ac3c65-54bf-48d0-abd5-94aee79f157a"
                             ],
@@ -814,14 +769,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "5eeb0b07-4986-4385-9776-56e4691142db",
+                            "id": "8400077f-7073-442c-907b-2fd145a43b29",
                             "type": "default",
                             "extras": {},
-                            "x": 808.6625169317036,
-                            "y": 69.46249359567165,
+                            "x": 742.9168233238464,
+                            "y": -92.69788372530398,
                             "name": "parameter-gr.Blocks-app",
                             "alignment": "left",
-                            "parentNode": "a1446472-fd26-4b3c-9c88-2a09cdd3919d",
+                            "parentNode": "1e0206e0-4790-4aee-a4c7-08966461c28d",
                             "links": [
                                 "9daf4b70-90db-404a-b2f2-4423bc8b9c51"
                             ],
@@ -832,14 +787,14 @@
                             "dataType": "gr.Blocks"
                         },
                         {
-                            "id": "2ff8fb62-8d99-4c77-8d2b-65532cd3d49e",
+                            "id": "55bd1948-1aab-45d0-b73b-1132f2b5ee59",
                             "type": "default",
                             "extras": {},
-                            "x": 930.9748820118846,
-                            "y": 47.86249311381515,
+                            "x": 865.4999165002014,
+                            "y": -114.03120738406709,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "a1446472-fd26-4b3c-9c88-2a09cdd3919d",
+                            "parentNode": "1e0206e0-4790-4aee-a4c7-08966461c28d",
                             "links": [
                                 "fbf0f762-2964-4022-8008-e7ee22bab482"
                             ],
@@ -853,172 +808,15 @@
                     "name": "GradioLaunch",
                     "color": "blue",
                     "portsInOrder": [
-                        "16a717ec-f9b0-4dda-ac08-d24743f7b46e",
-                        "5eeb0b07-4986-4385-9776-56e4691142db"
+                        "9d274d1b-667f-49b4-b02e-38a7d45e616b",
+                        "8400077f-7073-442c-907b-2fd145a43b29"
                     ],
                     "portsOutOrder": [
-                        "2ff8fb62-8d99-4c77-8d2b-65532cd3d49e"
+                        "55bd1948-1aab-45d0-b73b-1132f2b5ee59"
                     ]
                 },
-                "e61069e0-b824-4b9a-ac6a-636875bc6058": {
-                    "id": "e61069e0-b824-4b9a-ac6a-636875bc6058",
-                    "type": "custom-node",
-                    "selected": false,
-                    "extras": {
-                        "type": "dict",
-                        "attached": false
-                    },
-                    "x": -11.466684977213518,
-                    "y": 277.3703703703703,
-                    "ports": [
-                        {
-                            "id": "fd846aff-01e9-4f2d-8dbf-a6a919ef4334",
-                            "type": "default",
-                            "extras": {},
-                            "x": 169.52500793704905,
-                            "y": 308.86249391690933,
-                            "name": "out-0",
-                            "alignment": "right",
-                            "parentNode": "e61069e0-b824-4b9a-ac6a-636875bc6058",
-                            "links": [
-                                "a48b5fae-83bf-47fa-b422-d4ea40ff467e"
-                            ],
-                            "in": false,
-                            "label": "\"hello\": \"Hi there!\",\n\"how are you\": \"I'm doing great!\",\n\"bye\": \"Goodbye!\"\n\n",
-                            "varName": "\"hello\": \"Hi there!\",\n\"how are you\": \"I'm doing great!\",\n\"bye\": \"Goodbye!\"\n\n",
-                            "portType": "",
-                            "dataType": "dict"
-                        }
-                    ],
-                    "name": "Literal Dict",
-                    "color": "orange",
-                    "portsInOrder": [],
-                    "portsOutOrder": [
-                        "fd846aff-01e9-4f2d-8dbf-a6a919ef4334"
-                    ]
-                },
-                "0a824373-6b7d-4a8c-a157-e5bd78d298c5": {
-                    "id": "0a824373-6b7d-4a8c-a157-e5bd78d298c5",
-                    "type": "custom-node",
-                    "selected": false,
-                    "extras": {
-                        "type": "boolean",
-                        "attached": false
-                    },
-                    "x": 555.7703642668548,
-                    "y": 361.6296296296296,
-                    "ports": [
-                        {
-                            "id": "f83fae1e-311b-4053-89fa-a7f51df0ca93",
-                            "type": "default",
-                            "extras": {},
-                            "x": 625.3500105069503,
-                            "y": 385.42499391690933,
-                            "name": "out-0",
-                            "alignment": "right",
-                            "parentNode": "0a824373-6b7d-4a8c-a157-e5bd78d298c5",
-                            "links": [
-                                "f3a69f37-e68a-4033-bc0b-ed02bbcfa690"
-                            ],
-                            "in": false,
-                            "label": "True",
-                            "varName": "True",
-                            "portType": "",
-                            "dataType": "boolean"
-                        }
-                    ],
-                    "name": "Literal Boolean",
-                    "color": "red",
-                    "portsInOrder": [],
-                    "portsOutOrder": [
-                        "f83fae1e-311b-4053-89fa-a7f51df0ca93"
-                    ]
-                },
-                "28fa981b-4925-48ea-a8d4-4d894b58b6f0": {
-                    "id": "28fa981b-4925-48ea-a8d4-4d894b58b6f0",
-                    "type": "custom-node",
-                    "selected": false,
-                    "extras": {
-                        "type": "library_component",
-                        "path": "xai_components/xai_gradio/gradio_component.py",
-                        "description": "Stores a dictionary of predefined responses in the context.",
-                        "lineNo": [
-                            {
-                                "lineno": 464,
-                                "end_lineno": 471
-                            }
-                        ]
-                    },
-                    "x": 210.7703642668549,
-                    "y": 78.85185185185186,
-                    "ports": [
-                        {
-                            "id": "b3dbaabd-a248-414d-be3d-9723a1b24011",
-                            "type": "default",
-                            "extras": {},
-                            "x": 211.56257025715595,
-                            "y": 105.64999680804829,
-                            "name": "in-0",
-                            "alignment": "left",
-                            "parentNode": "28fa981b-4925-48ea-a8d4-4d894b58b6f0",
-                            "links": [
-                                "74d50325-134b-499b-964d-59d17a326413"
-                            ],
-                            "in": true,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        },
-                        {
-                            "id": "4a9a0f9e-5192-435c-b49c-48f0340c69b1",
-                            "type": "default",
-                            "extras": {},
-                            "x": 211.56257025715595,
-                            "y": 127.25001736725882,
-                            "name": "parameter-dict-responses_dict",
-                            "alignment": "left",
-                            "parentNode": "28fa981b-4925-48ea-a8d4-4d894b58b6f0",
-                            "links": [
-                                "a48b5fae-83bf-47fa-b422-d4ea40ff467e"
-                            ],
-                            "in": true,
-                            "label": "responses_dict",
-                            "varName": "responses_dict",
-                            "portType": "",
-                            "dataType": "dict"
-                        },
-                        {
-                            "id": "e165cfb4-312f-47ae-898c-8fbb0c34b695",
-                            "type": "default",
-                            "extras": {},
-                            "x": 354.0250496979454,
-                            "y": 105.64999680804829,
-                            "name": "out-0",
-                            "alignment": "right",
-                            "parentNode": "28fa981b-4925-48ea-a8d4-4d894b58b6f0",
-                            "links": [
-                                "e2b073c1-e83b-4d2e-bff8-14c9b3cb1ede"
-                            ],
-                            "in": false,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        }
-                    ],
-                    "name": "GradioResponses",
-                    "color": "purple",
-                    "portsInOrder": [
-                        "b3dbaabd-a248-414d-be3d-9723a1b24011",
-                        "4a9a0f9e-5192-435c-b49c-48f0340c69b1"
-                    ],
-                    "portsOutOrder": [
-                        "e165cfb4-312f-47ae-898c-8fbb0c34b695"
-                    ]
-                },
-                "060bdc94-b9bf-4a14-96b4-9f0ce943ac53": {
-                    "id": "060bdc94-b9bf-4a14-96b4-9f0ce943ac53",
+                "0aba0db7-12f7-403e-8251-50696047142e": {
+                    "id": "0aba0db7-12f7-403e-8251-50696047142e",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -1030,23 +828,22 @@
                                 "lineno": 52,
                                 "end_lineno": 82
                             }
-                        ],
-                        "borderColor": "rgb(0,192,255)"
+                        ]
                     },
-                    "x": -108.67408017758952,
-                    "y": 77.00000000000003,
+                    "x": 227.39224169645985,
+                    "y": 75.07197669990492,
                     "ports": [
                         {
-                            "id": "19fb0d11-0acc-41e5-9fa9-7c1c129fb63e",
+                            "id": "8db668e0-7aad-4d64-886a-ef2bd9de0ed4",
                             "type": "default",
                             "extras": {},
-                            "x": -107.86251069473549,
-                            "y": 103.79998909834434,
+                            "x": 228.05209515650594,
+                            "y": 101.7292010307603,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "060bdc94-b9bf-4a14-96b4-9f0ce943ac53",
+                            "parentNode": "0aba0db7-12f7-403e-8251-50696047142e",
                             "links": [
-                                "3a27aa4a-b186-4084-ad71-9c5efba1a324"
+                                "bd8d2655-88e1-4616-9b09-bc2ecb8a4d2a"
                             ],
                             "in": true,
                             "label": "▶",
@@ -1055,14 +852,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "4ead13ca-6132-491d-8475-5853b4c177a3",
+                            "id": "aa3a3727-a233-4867-ad3f-8de3d4061f91",
                             "type": "default",
                             "extras": {},
-                            "x": -107.86251069473549,
-                            "y": 125.40000965755488,
+                            "x": 228.05209515650594,
+                            "y": 123.0625246895234,
                             "name": "parameter-secret-organization",
                             "alignment": "left",
-                            "parentNode": "060bdc94-b9bf-4a14-96b4-9f0ce943ac53",
+                            "parentNode": "0aba0db7-12f7-403e-8251-50696047142e",
                             "links": [],
                             "in": true,
                             "label": "organization",
@@ -1071,14 +868,14 @@
                             "dataType": "secret"
                         },
                         {
-                            "id": "d4bc963e-6b74-4ad5-a794-af0fcc9bb7cd",
+                            "id": "dc3163a7-af3f-4bd1-abe6-83e188d3d42f",
                             "type": "default",
                             "extras": {},
-                            "x": -107.86251069473549,
-                            "y": 146.99999006205735,
+                            "x": 228.05209515650594,
+                            "y": 144.3958483482865,
                             "name": "parameter-string-base_url",
                             "alignment": "left",
-                            "parentNode": "060bdc94-b9bf-4a14-96b4-9f0ce943ac53",
+                            "parentNode": "0aba0db7-12f7-403e-8251-50696047142e",
                             "links": [],
                             "in": true,
                             "label": "base_url",
@@ -1087,15 +884,17 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "f569c930-1466-4755-882b-717abc65e85e",
+                            "id": "1a06879d-c366-4bd6-98dd-3e178dc84d59",
                             "type": "default",
                             "extras": {},
-                            "x": -107.86251069473549,
-                            "y": 168.5999704665598,
+                            "x": 228.05209515650594,
+                            "y": 165.72917200704964,
                             "name": "parameter-secret-api_key",
                             "alignment": "left",
-                            "parentNode": "060bdc94-b9bf-4a14-96b4-9f0ce943ac53",
-                            "links": [],
+                            "parentNode": "0aba0db7-12f7-403e-8251-50696047142e",
+                            "links": [
+                                "bf227e13-dced-42b2-bbe4-2dca4bd1a797"
+                            ],
                             "in": true,
                             "label": "api_key",
                             "varName": "api_key",
@@ -1103,14 +902,14 @@
                             "dataType": "secret"
                         },
                         {
-                            "id": "3304af90-d113-49e1-8d56-204f1821fcbe",
+                            "id": "e1245acf-524d-43aa-b63f-782283dff31f",
                             "type": "default",
                             "extras": {},
-                            "x": -107.86251069473549,
-                            "y": 190.19999102577032,
+                            "x": 228.05209515650594,
+                            "y": 187.06249566581275,
                             "name": "parameter-boolean-from_env",
                             "alignment": "left",
-                            "parentNode": "060bdc94-b9bf-4a14-96b4-9f0ce943ac53",
+                            "parentNode": "0aba0db7-12f7-403e-8251-50696047142e",
                             "links": [],
                             "in": true,
                             "label": "from_env",
@@ -1119,16 +918,16 @@
                             "dataType": "boolean"
                         },
                         {
-                            "id": "7fb557cc-98dc-4e56-921e-abbea92a12b0",
+                            "id": "fb2c4637-e1e4-42e4-91af-16919a60d760",
                             "type": "default",
                             "extras": {},
-                            "x": 30.325018216654303,
-                            "y": 103.79998909834434,
+                            "x": 366.5103684505947,
+                            "y": 101.7292010307603,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "060bdc94-b9bf-4a14-96b4-9f0ce943ac53",
+                            "parentNode": "0aba0db7-12f7-403e-8251-50696047142e",
                             "links": [
-                                "74d50325-134b-499b-964d-59d17a326413"
+                                "be1591d8-442d-48ae-8a26-86886a4652c8"
                             ],
                             "in": false,
                             "label": "▶",
@@ -1138,16 +937,591 @@
                         }
                     ],
                     "name": "OpenAIAuthorize",
-                    "color": "rgb(102,102,102)",
+                    "color": "rgb(255,102,0)",
                     "portsInOrder": [
-                        "19fb0d11-0acc-41e5-9fa9-7c1c129fb63e",
-                        "4ead13ca-6132-491d-8475-5853b4c177a3",
-                        "d4bc963e-6b74-4ad5-a794-af0fcc9bb7cd",
-                        "f569c930-1466-4755-882b-717abc65e85e",
-                        "3304af90-d113-49e1-8d56-204f1821fcbe"
+                        "8db668e0-7aad-4d64-886a-ef2bd9de0ed4",
+                        "aa3a3727-a233-4867-ad3f-8de3d4061f91",
+                        "dc3163a7-af3f-4bd1-abe6-83e188d3d42f",
+                        "1a06879d-c366-4bd6-98dd-3e178dc84d59",
+                        "e1245acf-524d-43aa-b63f-782283dff31f"
                     ],
                     "portsOutOrder": [
-                        "7fb557cc-98dc-4e56-921e-abbea92a12b0"
+                        "fb2c4637-e1e4-42e4-91af-16919a60d760"
+                    ]
+                },
+                "0d8d7ca1-736c-4509-9236-9fc021d89a90": {
+                    "id": "0d8d7ca1-736c-4509-9236-9fc021d89a90",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "string",
+                        "attached": true
+                    },
+                    "x": 672.2930325824027,
+                    "y": 443.0482849325343,
+                    "ports": [
+                        {
+                            "id": "4eb83e1c-78f9-44aa-a173-4961ad1564be",
+                            "type": "default",
+                            "extras": {},
+                            "x": 672.2930325824027,
+                            "y": 443.0482849325343,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "0d8d7ca1-736c-4509-9236-9fc021d89a90",
+                            "links": [
+                                "c4555c5f-6b89-464a-b61c-f1903c5d54cd"
+                            ],
+                            "in": false,
+                            "label": "gpt-4o-mini",
+                            "varName": "gpt-4o-mini",
+                            "portType": "",
+                            "dataType": "string"
+                        }
+                    ],
+                    "name": "Literal String",
+                    "color": "lightpink",
+                    "portsInOrder": [],
+                    "portsOutOrder": [
+                        "4eb83e1c-78f9-44aa-a173-4961ad1564be"
+                    ]
+                },
+                "4aa571b8-0e04-445e-aa5b-5e412e0867ff": {
+                    "id": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "library_component",
+                        "path": "xai_components/xai_openai/openai_components.py",
+                        "description": "Interacts with a specified model from OpenAI in a conversation.\n\n#### Reference:\n- [OpenAI API](https://platform.openai.com/docs/api-reference/completions/create)\n\n##### inPorts:\n- model_name: Name of the model to be used for conversation.\n- system_prompt: Initial system message to start the conversation.\n- user_prompt: Initial user message to continue the conversation.\n- conversation: A list of conversation messages. Each message is a dictionary with a \"role\" and \"content\".\n- max_tokens: The maximum length of the generated text.\n- temperature: Controls randomness of the output text.\n- count: Number of responses to generate.\n\n##### outPorts:\n- completion: The generated text of the model's response.\n- out_conversation: The complete conversation including the model's response.",
+                        "lineNo": [
+                            {
+                                "lineno": 173,
+                                "end_lineno": 237
+                            }
+                        ]
+                    },
+                    "x": 1028.56014545128,
+                    "y": 67.88095910351088,
+                    "ports": [
+                        {
+                            "id": "f5e628bb-b13f-4e1f-afaa-6f1227660fe8",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1029.2187416203938,
+                            "y": 94.54167115341107,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                            "links": [
+                                "67fe2867-8b94-4f28-981c-d30155ea8f3d"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "43963c28-83be-4d6e-8736-9ca3ef8dca5c",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1029.2187416203938,
+                            "y": 115.87505883506536,
+                            "name": "parameter-string-model_name",
+                            "alignment": "left",
+                            "parentNode": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                            "links": [
+                                "c4555c5f-6b89-464a-b61c-f1903c5d54cd"
+                            ],
+                            "in": true,
+                            "label": "★model_name",
+                            "varName": "★model_name",
+                            "portType": "",
+                            "dataType": "string"
+                        },
+                        {
+                            "id": "57cc41f4-83ca-4f01-9d1a-a7fccaf1f23d",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1029.2187416203938,
+                            "y": 135.8750417622944,
+                            "name": "parameter-string-system_prompt",
+                            "alignment": "left",
+                            "parentNode": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                            "links": [
+                                "9ab34629-0c2f-4e2e-9851-0a92ed710654"
+                            ],
+                            "in": true,
+                            "label": "system_prompt",
+                            "varName": "system_prompt",
+                            "portType": "",
+                            "dataType": "string"
+                        },
+                        {
+                            "id": "b4a12b56-948f-47cb-98d8-1034a86acc4c",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1029.2187416203938,
+                            "y": 155.8750246895234,
+                            "name": "parameter-string-user_prompt",
+                            "alignment": "left",
+                            "parentNode": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                            "links": [
+                                "8c2fc724-37a7-4710-92fd-0e8c6a94a3da"
+                            ],
+                            "in": true,
+                            "label": "user_prompt",
+                            "varName": "user_prompt",
+                            "portType": "",
+                            "dataType": "string"
+                        },
+                        {
+                            "id": "b49eb610-a088-4abb-82bb-e03e4c5d4007",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1029.2187416203938,
+                            "y": 177.2083483482865,
+                            "name": "parameter-list-conversation",
+                            "alignment": "left",
+                            "parentNode": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                            "links": [
+                                "b6c7b093-7041-45f5-818c-adb1bf566b97"
+                            ],
+                            "in": true,
+                            "label": "conversation",
+                            "varName": "conversation",
+                            "portType": "",
+                            "dataType": "list"
+                        },
+                        {
+                            "id": "bcea14a8-5b5a-42ce-a80f-6a6a69acc866",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1029.2187416203938,
+                            "y": 198.54167200704964,
+                            "name": "parameter-int-max_tokens",
+                            "alignment": "left",
+                            "parentNode": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                            "links": [],
+                            "in": true,
+                            "label": "max_tokens",
+                            "varName": "max_tokens",
+                            "portType": "",
+                            "dataType": "int"
+                        },
+                        {
+                            "id": "461d6cf0-c0ef-41dc-9c13-71c829c7d667",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1029.2187416203938,
+                            "y": 219.87499566581275,
+                            "name": "parameter-float-temperature",
+                            "alignment": "left",
+                            "parentNode": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                            "links": [],
+                            "in": true,
+                            "label": "temperature",
+                            "varName": "temperature",
+                            "portType": "",
+                            "dataType": "float"
+                        },
+                        {
+                            "id": "15e4da3d-b645-4097-a7ba-6b7738a41839",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1029.2187416203938,
+                            "y": 241.20838334746702,
+                            "name": "parameter-int-count",
+                            "alignment": "left",
+                            "parentNode": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                            "links": [],
+                            "in": true,
+                            "label": "count",
+                            "varName": "count",
+                            "portType": "",
+                            "dataType": "int"
+                        },
+                        {
+                            "id": "dc9c3085-abb7-4add-9e3f-038b5c850d66",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1326.8749916203938,
+                            "y": 94.54167115341107,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                            "links": [
+                                "bd735439-03b2-4e7b-9d35-3977a144c90b"
+                            ],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "57cfe194-a785-4bfa-bdfc-7de5ec46ce63",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1326.8749916203938,
+                            "y": 115.87505883506536,
+                            "name": "parameter-out-string-completion",
+                            "alignment": "right",
+                            "parentNode": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                            "links": [
+                                "22d03bd8-4ae2-4650-a659-be042d6d2ee7"
+                            ],
+                            "in": false,
+                            "label": "completion",
+                            "varName": "completion",
+                            "portType": "",
+                            "dataType": "string"
+                        },
+                        {
+                            "id": "8e54ea2f-5a07-4ac3-91cf-10754c9dbccc",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1326.8749916203938,
+                            "y": 137.20838249382848,
+                            "name": "parameter-out-list-out_conversation",
+                            "alignment": "right",
+                            "parentNode": "4aa571b8-0e04-445e-aa5b-5e412e0867ff",
+                            "links": [],
+                            "in": false,
+                            "label": "out_conversation",
+                            "varName": "out_conversation",
+                            "portType": "",
+                            "dataType": "list"
+                        }
+                    ],
+                    "name": "OpenAIChat",
+                    "color": "rgb(255,153,102)",
+                    "portsInOrder": [
+                        "f5e628bb-b13f-4e1f-afaa-6f1227660fe8",
+                        "43963c28-83be-4d6e-8736-9ca3ef8dca5c",
+                        "57cc41f4-83ca-4f01-9d1a-a7fccaf1f23d",
+                        "b4a12b56-948f-47cb-98d8-1034a86acc4c",
+                        "b49eb610-a088-4abb-82bb-e03e4c5d4007",
+                        "bcea14a8-5b5a-42ce-a80f-6a6a69acc866",
+                        "461d6cf0-c0ef-41dc-9c13-71c829c7d667",
+                        "15e4da3d-b645-4097-a7ba-6b7738a41839"
+                    ],
+                    "portsOutOrder": [
+                        "dc9c3085-abb7-4add-9e3f-038b5c850d66",
+                        "57cfe194-a785-4bfa-bdfc-7de5ec46ce63",
+                        "8e54ea2f-5a07-4ac3-91cf-10754c9dbccc"
+                    ]
+                },
+                "6f29bfeb-4597-4402-a8a1-8a3f6a30bfcf": {
+                    "id": "6f29bfeb-4597-4402-a8a1-8a3f6a30bfcf",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "string",
+                        "attached": true
+                    },
+                    "x": 818.0414353813073,
+                    "y": -9.87231135587458,
+                    "ports": [
+                        {
+                            "id": "5852b1fd-f568-4557-9f1c-3ed061b6f340",
+                            "type": "default",
+                            "extras": {},
+                            "x": 818.0414353813073,
+                            "y": -9.87231135587458,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "6f29bfeb-4597-4402-a8a1-8a3f6a30bfcf",
+                            "links": [
+                                "9ab34629-0c2f-4e2e-9851-0a92ed710654"
+                            ],
+                            "in": false,
+                            "label": "You are a helpful AI assistant.",
+                            "varName": "You are a helpful AI assistant.",
+                            "portType": "",
+                            "dataType": "string"
+                        }
+                    ],
+                    "name": "Literal String",
+                    "color": "lightpink",
+                    "portsInOrder": [],
+                    "portsOutOrder": [
+                        "5852b1fd-f568-4557-9f1c-3ed061b6f340"
+                    ]
+                },
+                "b2e4e0c4-fefd-4091-9d51-800b8726cfde": {
+                    "id": "b2e4e0c4-fefd-4091-9d51-800b8726cfde",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "library_component",
+                        "path": "xai_components/xai_gradio/gradio_component.py",
+                        "description": "Creates a deep copy of the input data and outputs the copied data.\n\n##### inPorts:\n- data (any): The input data to be deep-copied.\n\n##### outPorts:\n- copied_data (any): The deep-copied output data.",
+                        "lineNo": [
+                            {
+                                "lineno": 96,
+                                "end_lineno": 114
+                            }
+                        ]
+                    },
+                    "x": 807.8923173841802,
+                    "y": 69.4874551135407,
+                    "ports": [
+                        {
+                            "id": "716e950b-c151-4d87-b942-fa3bca9d4c42",
+                            "type": "default",
+                            "extras": {},
+                            "x": 808.5520669864338,
+                            "y": 96.14589273749105,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "b2e4e0c4-fefd-4091-9d51-800b8726cfde",
+                            "links": [
+                                "d7dc6c89-4494-4b81-9376-c53967c23d29"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "f5affac9-e009-40c5-8441-0ff686e3b644",
+                            "type": "default",
+                            "extras": {},
+                            "x": 808.5520669864338,
+                            "y": 117.47921639625417,
+                            "name": "parameter-any-data",
+                            "alignment": "left",
+                            "parentNode": "b2e4e0c4-fefd-4091-9d51-800b8726cfde",
+                            "links": [
+                                "1f456ffd-259d-4e42-9f88-f63e9707d8ff"
+                            ],
+                            "in": true,
+                            "label": "data",
+                            "varName": "data",
+                            "portType": "",
+                            "dataType": "any"
+                        },
+                        {
+                            "id": "b572a446-ba8a-433b-a963-4241bb16b00f",
+                            "type": "default",
+                            "extras": {},
+                            "x": 940.2499711330685,
+                            "y": 96.14589273749105,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "b2e4e0c4-fefd-4091-9d51-800b8726cfde",
+                            "links": [
+                                "67fe2867-8b94-4f28-981c-d30155ea8f3d"
+                            ],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "e705d21e-54c5-4b7d-b158-a97832f963c7",
+                            "type": "default",
+                            "extras": {},
+                            "x": 940.2499711330685,
+                            "y": 117.47921639625417,
+                            "name": "parameter-out-any-copied_data",
+                            "alignment": "right",
+                            "parentNode": "b2e4e0c4-fefd-4091-9d51-800b8726cfde",
+                            "links": [
+                                "b6c7b093-7041-45f5-818c-adb1bf566b97"
+                            ],
+                            "in": false,
+                            "label": "copied_data",
+                            "varName": "copied_data",
+                            "portType": "",
+                            "dataType": "any"
+                        }
+                    ],
+                    "name": "DeepCopy",
+                    "color": "rgb(153,204,51)",
+                    "portsInOrder": [
+                        "716e950b-c151-4d87-b942-fa3bca9d4c42",
+                        "f5affac9-e009-40c5-8441-0ff686e3b644"
+                    ],
+                    "portsOutOrder": [
+                        "b572a446-ba8a-433b-a963-4241bb16b00f",
+                        "e705d21e-54c5-4b7d-b158-a97832f963c7"
+                    ]
+                },
+                "874c9d4b-4871-41d2-ad42-079fb6f21b9e": {
+                    "id": "874c9d4b-4871-41d2-ad42-079fb6f21b9e",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "library_component",
+                        "path": "xai_components/xai_gradio/gradio_component.py",
+                        "description": "Handles the chat history and appends responses from a OpenAI-like Chat to it.\nInternally updates `ctx['__gradio_chat_history__']` for `GradioChatInterface` to process.\n\n##### inPorts:\n- message (str): The user's message just sent.\n- history (list): The conversation so far. Typically connected from the `GradioChatInterface` component.\n- llm_response (str/dict): The raw LLM response from the model.\n- log_file (str): Path to optionally log the conversation.\n\n##### outPorts:",
+                        "lineNo": [
+                            {
+                                "lineno": 249,
+                                "end_lineno": 292
+                            }
+                        ]
+                    },
+                    "x": 1502.0216526442957,
+                    "y": 366.0192470210552,
+                    "ports": [
+                        {
+                            "id": "516bbda0-e001-4659-a525-fd93f602051a",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1502.6874847912854,
+                            "y": 392.67706847093734,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "874c9d4b-4871-41d2-ad42-079fb6f21b9e",
+                            "links": [
+                                "bd735439-03b2-4e7b-9d35-3977a144c90b"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "846cbcfb-08de-4325-9dd0-a49ff16143c0",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1502.6874847912854,
+                            "y": 414.0104561525916,
+                            "name": "parameter-string-message",
+                            "alignment": "left",
+                            "parentNode": "874c9d4b-4871-41d2-ad42-079fb6f21b9e",
+                            "links": [
+                                "a9ef593a-9fe5-4969-a1bc-f8aa98160107"
+                            ],
+                            "in": true,
+                            "label": "message",
+                            "varName": "message",
+                            "portType": "",
+                            "dataType": "string"
+                        },
+                        {
+                            "id": "1bc9391d-85d7-4a06-9d00-ab32f388e8ef",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1502.6874847912854,
+                            "y": 435.34377981135475,
+                            "name": "parameter-list-history",
+                            "alignment": "left",
+                            "parentNode": "874c9d4b-4871-41d2-ad42-079fb6f21b9e",
+                            "links": [
+                                "8f64a4db-def3-44b3-9327-99bfa74b6388"
+                            ],
+                            "in": true,
+                            "label": "history",
+                            "varName": "history",
+                            "portType": "",
+                            "dataType": "list"
+                        },
+                        {
+                            "id": "14fd66f6-d2f8-4b42-bda4-96832579299b",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1502.6874847912854,
+                            "y": 456.67710347011786,
+                            "name": "parameter-any-llm_response",
+                            "alignment": "left",
+                            "parentNode": "874c9d4b-4871-41d2-ad42-079fb6f21b9e",
+                            "links": [
+                                "22d03bd8-4ae2-4650-a659-be042d6d2ee7"
+                            ],
+                            "in": true,
+                            "label": "llm_response",
+                            "varName": "llm_response",
+                            "portType": "",
+                            "dataType": "any"
+                        },
+                        {
+                            "id": "c2423c74-ee34-4d42-908b-7f205b9fee33",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1502.6874847912854,
+                            "y": 478.01042712888096,
+                            "name": "parameter-string-log_file",
+                            "alignment": "left",
+                            "parentNode": "874c9d4b-4871-41d2-ad42-079fb6f21b9e",
+                            "links": [],
+                            "in": true,
+                            "label": "log_file",
+                            "varName": "log_file",
+                            "portType": "",
+                            "dataType": "string"
+                        },
+                        {
+                            "id": "332a9670-5bf9-4bdc-a960-95adeb3ae9f5",
+                            "type": "default",
+                            "extras": {},
+                            "x": 1660.6772855179024,
+                            "y": 392.67706847093734,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "874c9d4b-4871-41d2-ad42-079fb6f21b9e",
+                            "links": [],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        }
+                    ],
+                    "name": "GradioChatFnReturn",
+                    "color": "purple",
+                    "portsInOrder": [
+                        "516bbda0-e001-4659-a525-fd93f602051a",
+                        "846cbcfb-08de-4325-9dd0-a49ff16143c0",
+                        "1bc9391d-85d7-4a06-9d00-ab32f388e8ef",
+                        "14fd66f6-d2f8-4b42-bda4-96832579299b",
+                        "c2423c74-ee34-4d42-908b-7f205b9fee33"
+                    ],
+                    "portsOutOrder": [
+                        "332a9670-5bf9-4bdc-a960-95adeb3ae9f5"
+                    ]
+                },
+                "0c538b40-8c7f-4b25-9e78-4547d1a9dfbf": {
+                    "id": "0c538b40-8c7f-4b25-9e78-4547d1a9dfbf",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "secret"
+                    },
+                    "x": -43.06505255801656,
+                    "y": 251.5683799690321,
+                    "ports": [
+                        {
+                            "id": "83dfd1a2-c1ac-4b4d-bce6-7135867e657c",
+                            "type": "default",
+                            "extras": {},
+                            "x": 131.68746430396007,
+                            "y": 275.8957937154194,
+                            "name": "parameter-out-0",
+                            "alignment": "right",
+                            "parentNode": "0c538b40-8c7f-4b25-9e78-4547d1a9dfbf",
+                            "links": [
+                                "bf227e13-dced-42b2-bbe4-2dca4bd1a797"
+                            ],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": "secret"
+                        }
+                    ],
+                    "name": "Argument (secret): openai_api_key",
+                    "color": "black",
+                    "portsInOrder": [],
+                    "portsOutOrder": [
+                        "83dfd1a2-c1ac-4b4d-bce6-7135867e657c"
                     ]
                 }
             }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 gradio==4.44.0
 makefun==1.15.6
-openai==1.57.0


### PR DESCRIPTION
# Description

This PR:
- remove OpenAI as a dependency.
- Return `GradioFnReturn` to simplicity and adds `GradioChatFnReturn` which accepts a LLM-like response and work with `GradioChatInterface`
- properly implements Chat history
- temporarily removes image support from `GradioChatInterface` (we can re-add it once it is properly implemented)
- ensure `GradioChatExample` and `GradioAgentExample` works.

## References

https://github.com/XpressAI/xai-gradio/pull/3

## Pull Request Type

- [x] Xircuits Component Library Code
- [x] Workflow Example
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Tests

Run `GradioChatExample` and `GradioAgentExample`. Ensure that:
1. it works as expected from chat interface
2. remembers the previous message


## Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

## Notes

This requires an update for the front readme. We'll also need to give a users a heads up that they will need the OpenAI component library for the chat example, and OpenAI + Agents for the agent example. Also for Agents, tell them they will need a key for the weather.